### PR TITLE
[PR-1] docs: Add technical specification for Discord bot integration and iteration file (issue 2.0)

### DIFF
--- a/Task-2/docs/iterations/task-iteration1.md
+++ b/Task-2/docs/iterations/task-iteration1.md
@@ -1,0 +1,26 @@
+# Project: Meal Headcount Planner (MHP) — Task 2 (Weeks 3–4)
+Add a Discord bot as an input channel while evolving MHP into a production-grade system with DynamoDB persistence, a structured web dashboard, containerized runtime, and CI/CD.
+
+## Iteration 1 (Week 1) — Discord Input + Web Dashboard Architecture (FE3 + FE4 + BE3)
+### Feature requests
+1. **Discord bot: employee self-update**
+   - Employees can update their meal participation for a selected date.
+   - Employees can update their work location (Office/WFH) for a selected date.
+   - Bot replies with the user’s current status summary after each change.
+
+2. **Discord bot: team/admin quick views**
+   - Team Leads can request a team-level headcount summary for a selected date.
+   - Admin/Logistics can request overall headcount summary for a selected date.
+
+3. **Web dashboard: component-based UI**
+   - Admin/Logistics dashboard displays meal totals, Office vs WFH split, and special-day indicators.
+   - Team Lead view displays team participation list and rollups.
+   - UI is clearly organized into reusable components (filters, summary cards, employee list, day banner).
+
+4. **Web dashboard: shared state + live updates**
+   - Dashboard supports changing selected date and filters (team, meal type, WFH).
+   - Totals and rollups update immediately as filters or entries change.
+
+5. **Compute paradigm: async summary generation**
+   - When Admin triggers “Generate daily summary”, the system processes it asynchronously.
+   - UI/bot shows “in progress” → “ready” status.

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -82,39 +82,26 @@ All service choices minimize cost for low-to-medium usage internal tooling with 
 
 ### 2.3 DynamoDB Data Model (Proposed)
 
-One table per entity type (multi-table design). Cut-off time and event day configuration are handled via static settings, so only one DynamoDB table is required.
+Multi-table design with a maximum of 2 GSIs. Detailed table schemas, key design, GSI projections, and write strategy will be documented later.
 
----
+**Tables:**
 
-**Table: `mhp-meal-records`**
-
-| Attribute | Type | Role |
+| Table | Primary access direction | GSIs |
 | --- | --- | --- |
-| `date` | `String` | Partition key — `YYYY-MM-DD` |
-| `user_id` | `String` | Sort key — Discord user snowflake ID |
-| `meal_opt_in` | `Boolean` | Whether the user is having a meal that day. |
-| `work_location` | `String` | `OFFICE` or `WFH`. |
-| `meal_type` | `String` | e.g., `STANDARD`, `VEGETARIAN`. |
-| `updated_at` | `String` | ISO 8601 timestamp of last change. |
-| `updated_by` | `String` | Discord user ID of who made the change (self or admin). |
-
-**GSIs:**
-
-| GSI | PK | SK | Purpose |
-| --- | --- | --- | --- |
-| `user_date_index` | `user_id` | `date` | Query all meal records for a user across dates (user history, `/meal status`). |
-| `location_date_index` | `work_location` | `date` | Query all OFFICE or WFH records for a date (location-based headcount). |
+| `mhp-meal-records` | Date-centric — daily headcount and location/dietary breakdowns | 2 (`location_date_index`, `meal_type_date_index`) |
+| `mhp-user-history` | User-centric — per-user meal history across dates | None |
 
 **Access patterns:**
 
-| Operation | Pattern | Notes |
+| Operation | Table | Notes |
 | --- | --- | --- |
-| Get all records for a date | Query on `date` (PK) | Org-wide headcount and dashboard listing. |
-| Get one user's record for a date | GetItem on `date` + `user_id` | Direct key lookup; no GSI needed. |
-| Get a user's records across dates | Query `user_date_index` on `user_id` | Drives `/meal status` history and dashboard user view. |
-| Get OFFICE or WFH headcount for a date | Query `location_date_index` on `work_location`, filter `date` | No client-side scan needed for location filtering. |
-| Count opt-ins / opt-outs for a date | Query on `date` (PK), filter client-side | Headcount totals; acceptable for small org sizes. |
-| Create or update a user's record | PutItem on `date` + `user_id` | Covers opt-in, opt-out, location update, and admin override. |
+| Get all records for a date | `mhp-meal-records` | Org-wide headcount and dashboard listing. |
+| Get one user's record for a date | `mhp-meal-records` | Direct key lookup; no GSI needed. |
+| Get a user's records across dates | `mhp-user-history` | Drives `/meal status` history; no GSI needed. |
+| Get OFFICE or WFH headcount for a date | `mhp-meal-records` | Via `location_date_index`. |
+| Get dietary headcount for a date | `mhp-meal-records` | Via `meal_type_date_index` (e.g., VEGETARIAN count). |
+| Count opt-ins / opt-outs for a date | `mhp-meal-records` | Query by date, filter client-side. |
+| Create or update a user's record | Both tables | `mhp-meal-records` is authoritative; `mhp-user-history` is a denormalized read replica. |
 
 ---
 
@@ -177,6 +164,7 @@ Sensitive configuration is managed via a `Settings` class (Pydantic `BaseSetting
 | `DISCORD_PUBLIC_KEY` | Discord application's Ed25519 public key for signature verification. |
 | `DISCORD_BOT_TOKEN` | Bot token for sending follow-up messages via Discord REST API. |
 | `DYNAMODB_MEAL_TABLE` | Meal records table name (defaults to `mhp-meal-records`). |
+| `DYNAMODB_USER_HISTORY_TABLE` | User history table name (defaults to `mhp-user-history`). Denormalized read replica of `DYNAMODB_MEAL_TABLE` for user-first queries. |
 | `AWS_REGION` | AWS region for DynamoDB client (defaults to `ap-southeast-1`). |
 | `ROLE_TEAM_LEAD_ID` | Discord role ID for Team Lead permission level. |
 | `ROLE_ADMIN_ID` | Discord role ID for Admin/Logistics permission level. |

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -303,17 +303,6 @@ The system does **not** require every employee to explicitly opt in — absence 
 
 ### 5.4 Dependencies (`requirements.txt`)
 
-```text
-fastapi>=0.111.0
-uvicorn[standard]>=0.29.0
-mangum>=0.17.0
-boto3>=1.34.0
-pydantic>=2.7.0
-pydantic-settings>=2.2.0
-pynacl>=1.5.0
-python-dotenv>=1.0.0
-```
-
 | Package | Purpose |
 | --- | --- |
 | `fastapi` | Web framework — routing, dependency injection, request parsing. |
@@ -324,6 +313,53 @@ python-dotenv>=1.0.0
 | `pydantic-settings` | `BaseSettings` support for environment variable loading. |
 | `pynacl` | Ed25519 signature verification for Discord request authentication. |
 | `python-dotenv` | Loads `.env` file during local development (no-op in Lambda). |
+
+---
+
+## 5.5 API Endpoints
+
+All endpoints are served under the Lambda function URL proxied through API Gateway.
+
+### Discord Endpoints
+
+| Method | Path | Auth | Description |
+| --- | --- | --- | --- |
+| `POST` | `/interactions` | Ed25519 signature (§3.1) | Receives all Discord interaction events — slash commands, buttons, select menus. |
+| `GET` | `/health` | None | Lambda warm-up and load balancer health check. |
+
+### Discord Slash Commands
+
+Registered via the Discord Developer Portal. Each command maps to a handler inside `app/api/interactions.py`.
+
+| Command | Permission | Description |
+| --- | --- | --- |
+| `/meal status [date]` | Employee | Show own meal opt-in and work location for a date (defaults to today). |
+| `/meal update` | Employee | Update own meal opt-in or work location for a date. |
+| `/meal optout <date>` | Employee | Opt out of an event meal for a specific date. |
+| `/meal summary <date>` | Team Lead | Show team headcount summary for a date. |
+| `/meal summary-all <date>` | Admin | Show org-wide headcount summary for a date. |
+| `/meal override <user> <date>` | Admin | Override any employee's meal record. |
+| `/meal cutoff set <date> <time>` | Admin | Set a custom cut-off time for a specific date. |
+| `/meal event set <date> <desc>` | Admin | Flag a date as an event meal day and broadcast announcement. |
+
+### Backend REST API Endpoints
+
+Consumed by the web dashboard frontend, served under `/api/v1`. All require `Authorization: Bearer <INTERNAL_API_KEY>` and are not exposed to Discord.
+
+| Method | Path | Permission | Description |
+| --- | --- | --- | --- |
+| `GET` | `/api/v1/meals/{date}` | Admin / Team Lead | Get all meal records for a date. Supports `?team_id=` filter. |
+| `GET` | `/api/v1/meals/{date}/{user_id}` | Admin / Team Lead | Get a single user's meal record for a date. |
+| `PUT` | `/api/v1/meals/{date}/{user_id}` | Admin | Create or update a meal record for a user on a date. |
+| `DELETE` | `/api/v1/meals/{date}/{user_id}` | Admin | Delete a meal record (resets to implicit opt-in on event days). |
+| `GET` | `/api/v1/headcount/{date}` | Admin | Org-wide headcount summary for a date. |
+| `GET` | `/api/v1/headcount/{date}/teams/{team_id}` | Team Lead | Team-level headcount summary for a date. |
+| `GET` | `/api/v1/config/cutoff/{date}` | Admin | Get the cut-off time for a specific date. |
+| `PUT` | `/api/v1/config/cutoff/{date}` | Admin | Set or override the cut-off time for a specific date. |
+| `DELETE` | `/api/v1/config/cutoff/{date}` | Admin | Remove override — reverts to `DEFAULT_CUTOFF_TIME`. |
+| `GET` | `/api/v1/events/{date}` | Admin / Team Lead | Get event meal details for a date. Returns `404` if not an event day. |
+| `POST` | `/api/v1/events` | Admin | Create a new event meal day. |
+| `DELETE` | `/api/v1/events/{date}` | Admin | Remove event meal flag from a date. |
 
 ---
 

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -82,25 +82,25 @@ All service choices minimize cost for low-to-medium usage internal tooling with 
 
 ### 2.3 DynamoDB Data Model (Proposed)
 
-Multi-table design with a maximum of 2 GSIs. Detailed table schemas, key design, GSI projections, and write strategy will be documented later.
+Multi-table design with no GSIs. All aggregation queries retrieve the full record set for a date and filter client-side — a sufficient strategy given the bounded per-day record count of an internal tool.
 
 **Tables:**
 
-| Table | Primary access direction | GSIs |
-| --- | --- | --- |
-| `mhp-meal-records` | Date-centric — daily headcount and location/dietary breakdowns | 2 (`location_date_index`, `meal_type_date_index`) |
-| `mhp-user-history` | User-centric — per-user meal history across dates | None |
+| Table | PK | SK | GSIs |
+| --- | --- | --- | --- |
+| `mhp-meal-records` | `DATE#{date}` | `USER#{user_id}` | None |
+| `mhp-user-history` | `USER#{user_id}` | `DATE#{date}` | None |
 
 **Access patterns:**
 
-| Operation | Table | Notes |
+| Operation | Table | Key strategy |
 | --- | --- | --- |
-| Get all records for a date | `mhp-meal-records` | Org-wide headcount and dashboard listing. |
-| Get one user's record for a date | `mhp-meal-records` | Direct key lookup; no GSI needed. |
-| Get a user's records across dates | `mhp-user-history` | Drives `/meal status` history; no GSI needed. |
-| Get OFFICE or WFH headcount for a date | `mhp-meal-records` | Via `location_date_index`. |
-| Get dietary headcount for a date | `mhp-meal-records` | Via `meal_type_date_index` (e.g., VEGETARIAN count). |
-| Count opt-ins / opt-outs for a date | `mhp-meal-records` | Query by date, filter client-side. |
+| Get all records for a date | `mhp-meal-records` | `Query(PK=DATE#{date})` — base table. |
+| Get one user's record for a date | `mhp-meal-records` | `GetItem(PK=DATE#{date}, SK=USER#{user_id})` — direct key lookup. |
+| Get a user's records across dates | `mhp-user-history` | `Query(PK=USER#{user_id})` — base table. |
+| Get OFFICE or WFH headcount for a date | `mhp-meal-records` | `Query(PK=DATE#{date})` + client-side filter on `work_location`. |
+| Get dietary headcount for a date | `mhp-meal-records` | `Query(PK=DATE#{date})` + client-side filter on `meal_type`. |
+| Count opt-ins / opt-outs for a date | `mhp-meal-records` | `Query(PK=DATE#{date})` + client-side filter on `meal_opt_in`. |
 | Create or update a user's record | Both tables | `mhp-meal-records` is authoritative; `mhp-user-history` is a denormalized read replica. |
 
 ---

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -1,7 +1,7 @@
 # Meal Headcount Planner — Discord Bot Integration
 
-**Version:** 1.0    
-**Date:** 2026-03-02    
+**Version:** 1.1    
+**Date:** 2026-03-04    
 **Status:** Draft    
 
 ---
@@ -403,7 +403,6 @@ The following are explicitly deferred and must not be implemented until a subseq
 | CI/CD pipeline | GitHub Actions deployment workflow depends on IaC being in place first. |
 | AWS Secrets Manager integration | Env vars managed manually for now; Secrets Manager adds operational complexity before the app is validated. |
 | DynamoDB table creation | Table will be provisioned manually or via IaC in a future iteration. |
-| Discord slash command registration | Commands will be registered manually via the Discord Developer Portal in this iteration. |
 | Automated tests | Unit and integration test scaffolding is deferred until the core service layer is stable. |
 | Web dashboard changes | Dashboard updates are tracked separately under the FE track of this sprint. |
 

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -82,12 +82,16 @@ All service choices minimize cost for low-to-medium usage internal tooling with 
 
 ### 2.3 DynamoDB Data Model (Proposed)
 
+Three separate tables are used — one per entity type. This keeps queries simple and avoids advanced single-table patterns.
+
+---
+
 **Table: `mhp-meal-records`**
 
 | Attribute | Type | Role |
 | --- | --- | --- |
-| `PK` | `String` | Partition key — `USER#{discord_user_id}` |
-| `SK` | `String` | Sort key — `DATE#{YYYY-MM-DD}` |
+| `date` | `String` | Partition key — `YYYY-MM-DD` |
+| `user_id` | `String` | Sort key — Discord user snowflake ID |
 | `meal_opt_in` | `Boolean` | Whether the user is having a meal that day. |
 | `work_location` | `String` | `OFFICE` or `WFH`. |
 | `meal_type` | `String` | e.g., `STANDARD`, `VEGETARIAN`. |
@@ -96,9 +100,31 @@ All service choices minimize cost for low-to-medium usage internal tooling with 
 
 **Access patterns:**
 
-- Get a single user's record for a date → `PK + SK` (direct lookup).
-- Get all records for a date → GSI on `SK` (date-based fan-out).
-- Get all records for a team on a date → GSI on `SK` filtered by team attribute.
+- Get all records for a date → Query on `date` (partition key).
+- Get a single user's record for a date → Query on `date` + `user_id` (direct lookup, no GSI needed).
+
+---
+
+**Table: `mhp-cutoff-config`**
+
+| Attribute | Type | Role |
+| --- | --- | --- |
+| `date` | `String` | Partition key — `YYYY-MM-DD` |
+| `cutoff_time` | `String` | Cut-off time in `HH:MM` (24-hour) format. |
+
+**Access pattern:** Get cut-off time for a date → GetItem on `date`.
+
+---
+
+**Table: `mhp-events`**
+
+| Attribute | Type | Role |
+| --- | --- | --- |
+| `date` | `String` | Partition key — `YYYY-MM-DD` |
+| `description` | `String` | Event name or notes. |
+| `opt_out_deadline` | `String` | Cut-off time for opt-out in `HH:MM` format. |
+
+**Access pattern:** Check if a date is an event day → GetItem on `date`. Returns nothing if not an event day.
 
 ---
 
@@ -160,7 +186,9 @@ Sensitive configuration is managed via a `Settings` class (Pydantic `BaseSetting
 | --- | --- |
 | `DISCORD_PUBLIC_KEY` | Discord application's Ed25519 public key for signature verification. |
 | `DISCORD_BOT_TOKEN` | Bot token for sending follow-up messages via Discord REST API. |
-| `DYNAMODB_TABLE_NAME` | DynamoDB table name (defaults to `mhp-meal-records`). |
+| `DYNAMODB_MEAL_TABLE` | Meal records table name (defaults to `mhp-meal-records`). |
+| `DYNAMODB_CUTOFF_TABLE` | Cut-off config table name (defaults to `mhp-cutoff-config`). |
+| `DYNAMODB_EVENTS_TABLE` | Event meal table name (defaults to `mhp-events`). |
 | `AWS_REGION` | AWS region for DynamoDB client (defaults to `ap-southeast-1`). |
 | `ROLE_TEAM_LEAD_ID` | Discord role ID for Team Lead permission level. |
 | `ROLE_ADMIN_ID` | Discord role ID for Admin/Logistics permission level. |
@@ -227,13 +255,7 @@ if target_date > today:
 
 **Admin override:** Users with the `@Admin` / `@Logistics` role can bypass the cut-off check entirely. This allows last-minute corrections without a time gate.
 
-**Cut-off time storage:** The cut-off time for a given date is stored in a separate DynamoDB item:
-
-- `PK`: `CONFIG#CUTOFF`
-- `SK`: `DATE#{YYYY-MM-DD}`
-- `cutoff_time`: `HH:MM` string (24-hour format)
-
-If no record exists for a date, the system falls back to the `DEFAULT_CUTOFF_TIME` environment variable (default: `10:00`).
+**Cut-off time storage:** The cut-off time for a given date is stored in the `mhp-cutoff-config` table as a single item keyed by `date`. If no record exists for a date, the system falls back to the `DEFAULT_CUTOFF_TIME` environment variable (default: `10:00`).
 
 ---
 
@@ -244,11 +266,7 @@ An "Event Meal" is a special catering day (e.g., company anniversary, team lunch
 **Event day setup (Admin action):**
 
 1. Admin uses `/meal event set <date> <description>` to flag a date as an event meal day.
-2. The system writes an event record to DynamoDB:
-   - `PK`: `EVENT#<date>`
-   - `SK`: `META`
-   - `description`: event name/notes
-   - `opt_out_deadline`: cut-off time for that day (same rules as §4.1)
+2. The system writes an event record to the `mhp-events` table keyed by `date`, with `description` and `opt_out_deadline` fields (same cut-off rules as §4.1).
 3. The bot broadcasts a notification to the configured meal channel announcing the event and the opt-out deadline.
 
 **Employee opt-out flow:**

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -75,7 +75,7 @@ All service choices minimize cost for low-to-medium usage internal tooling with 
 | Service | Tier / Config | Cost Decision | Impact |
 | --- | --- | --- | --- |
 | **API Gateway** | HTTP API | HTTP API over REST API | ~70% cheaper per request; REST-only features (transformation, usage plans) are not needed. |
-| **AWS Lambda** | `arm64` (Graviton2), 512 MB | Graviton2 architecture | ~20% lower compute cost vs x86 at identical memory/duration. Cold starts acceptable for low-frequency tooling. A scheduled EventBridge warm-up ping (see §7) can partially mitigate cold starts during the predictable evening submission window at negligible cost. |
+| **AWS Lambda** | `arm64` (Graviton2), 512 MB | Graviton2 + SnapStart | ~20% lower compute cost vs x86. **SnapStart** (enabled on the published version) eliminates cold starts by restoring a pre-initialized execution environment snapshot — no warm-up pings or provisioned concurrency needed. Requires Python 3.12 runtime. |
 | **AWS Lambda** | Single function | One handler for all routes | Eliminates overhead of managing and cold-starting multiple per-route functions. A single `handler(event, context)` entry point dispatches to service functions by command name. |
 | **DynamoDB** | On-Demand capacity | No provisioned capacity | Zero cost at rest; scales automatically with bursty morning headcount traffic. |
 | **CloudWatch Logs** | 60-day retention | Minimal log retention | Prevents unbounded storage accumulation; sufficient for operational debugging. |
@@ -280,8 +280,8 @@ The system does **not** require every employee to explicitly opt in — absence 
 
 ### 5.1 Runtime
 
-- **Python version:** 3.11 (minimum). Required for optimal Lambda cold-start performance and full `tomllib` / `typing` support.
-- **Lambda runtime:** `python3.11` on `arm64` (Graviton2).
+- **Python version:** 3.12 (minimum). Required for Lambda SnapStart support and includes performance improvements over 3.11.
+- **Lambda runtime:** `python3.12` on `arm64` (Graviton2) with **SnapStart** enabled on the published function version.
 
 ### 5.2 Directory Layout
 
@@ -349,7 +349,7 @@ All endpoints are served under the Lambda function URL proxied through API Gatew
 | Method | Path | Auth | Description |
 | --- | --- | --- | --- |
 | `POST` | `/interactions` | Ed25519 signature (§3.1) | Receives all Discord interaction events — slash commands, buttons, select menus. |
-| `GET` | `/health` | None | Lambda warm-up and load balancer health check. Also the target for a scheduled EventBridge warm-up ping (see §7). |
+| `GET` | `/health` | None | Health check endpoint for monitoring and load balancer integration. |
 
 ### Discord Slash Commands
 
@@ -403,8 +403,7 @@ Items identified during architecture design that are intentionally queued for la
 - **CI/CD (GitHub Actions):** Automate linting, testing, packaging, and Lambda deployment on merge to `main`.
 - **AWS Secrets Manager:** Migrate `DISCORD_BOT_TOKEN` and `DISCORD_PUBLIC_KEY` from environment variables to Secrets Manager with automatic rotation.
 - **DynamoDB Streams → async processing:** Trigger a secondary Lambda on record changes to push live updates to the web dashboard without polling.
-- **Lambda warm-up via EventBridge (low-cost mitigation):** Schedule an EventBridge rule to `GET /health` every 5 minutes during the evening submission window (e.g., 19:00–23:59 local time, leading up to the 00:00 cut-off). This keeps the container warm before the peak usage period at negligible cost (~$0/month within free tier). Does not guarantee zero cold starts but eliminates them during the scheduled window. No code changes required — only an EventBridge rule and IAM permission to invoke the function URL.
-- **Lambda Provisioned Concurrency (full elimination):** Reserve a minimum number of pre-initialized execution environments. Eliminates cold starts entirely but incurs a fixed hourly cost; appropriate only if warm-up pings prove insufficient or if SLA requirements tighten.
+- **Lambda SnapStart:** Enable SnapStart on the published function version (Python 3.12 runtime). AWS takes a snapshot of the initialized execution environment after the first init and restores it on subsequent cold starts, reducing latency to near-warm levels. No scheduled pings, no provisioned concurrency, no additional cost beyond standard invocation pricing.
 - **Structured logging (AWS Powertools):** Replace raw `print`/`logging` calls with `aws_lambda_powertools` for structured JSON logs, tracing (X-Ray), and metrics.
 - **Rate limiting:** Add per-user request throttling at the API Gateway level to prevent abuse.
 

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -52,7 +52,7 @@ API Gateway (HTTP API)
      │
      │  Proxy integration
      ▼
-AWS Lambda (FastAPI via Mangum)
+AWS Lambda (plain handler)
      │
      ├──► DynamoDB (read / write meal records)
      │
@@ -62,9 +62,9 @@ AWS Lambda (FastAPI via Mangum)
 1. A Discord user triggers a slash command or button interaction.
 2. Discord sends a signed HTTP POST to the **API Gateway HTTP API** endpoint.
 3. API Gateway proxies the raw request (including signature headers) to a single **Lambda function**.
-4. The Lambda runs a **FastAPI** application adapted by **Mangum**, which:
+4. The Lambda handler (`app/handler.py`) runs synchronously and:
    - Validates the Ed25519 signature (reject immediately if invalid).
-   - Parses the interaction payload and routes it to the appropriate handler.
+   - Parses the interaction payload and routes to the appropriate service function.
    - Reads from / writes to **DynamoDB**.
    - Returns a JSON response to Discord (or defers and sends a follow-up).
 
@@ -75,10 +75,10 @@ All service choices minimize cost for low-to-medium usage internal tooling with 
 | Service | Tier / Config | Cost Decision | Impact |
 | --- | --- | --- | --- |
 | **API Gateway** | HTTP API | HTTP API over REST API | ~70% cheaper per request; REST-only features (transformation, usage plans) are not needed. |
-| **AWS Lambda** | `arm64` (Graviton2), 512 MB | Graviton2 architecture | ~20% lower compute cost vs x86 at identical memory/duration. Cold starts acceptable for low-frequency tooling. |
-| **AWS Lambda** | Single function | One function for all routes via FastAPI + Mangum | Eliminates overhead of managing and cold-starting multiple per-route functions. |
+| **AWS Lambda** | `arm64` (Graviton2), 512 MB | Graviton2 architecture | ~20% lower compute cost vs x86 at identical memory/duration. Cold starts acceptable for low-frequency tooling. A scheduled EventBridge warm-up ping (see §7) can partially mitigate cold starts during the predictable evening submission window at negligible cost. |
+| **AWS Lambda** | Single function | One handler for all routes | Eliminates overhead of managing and cold-starting multiple per-route functions. A single `handler(event, context)` entry point dispatches to service functions by command name. |
 | **DynamoDB** | On-Demand capacity | No provisioned capacity | Zero cost at rest; scales automatically with bursty morning headcount traffic. |
-| **CloudWatch Logs** | 7-day retention | Minimal log retention | Prevents unbounded storage accumulation; sufficient for operational debugging. |
+| **CloudWatch Logs** | 60-day retention | Minimal log retention | Prevents unbounded storage accumulation; sufficient for operational debugging. |
 
 ### 2.3 DynamoDB Data Model (Proposed)
 
@@ -146,7 +146,7 @@ Every request from Discord includes two headers that must be validated **before 
 3. If verification fails → return `HTTP 401` immediately, no further processing.
 4. If the timestamp is more than 5 minutes old → return `HTTP 401` (replay attack protection).
 
-This check runs as a FastAPI dependency, applied globally to all interaction endpoints.
+This check is called explicitly at the top of the Lambda handler before any routing or business logic executes.
 
 ```python
 # Pseudocode — implementation detail, not production code
@@ -193,8 +193,8 @@ Sensitive configuration is managed via a `Settings` class (Pydantic `BaseSetting
 | `ROLE_TEAM_LEAD_ID` | Discord role ID for Team Lead permission level. |
 | `ROLE_ADMIN_ID` | Discord role ID for Admin/Logistics permission level. |
 | `AUTHORIZED_GUILD_ID` | Discord guild (server) ID — interactions from other guilds are rejected (§3.4). |
-| `TIMEZONE` | IANA timezone for cut-off time evaluation (default: `Asia/Kuala_Lumpur`) (§4.1). |
-| `DEFAULT_CUTOFF_TIME` | Fallback cut-off time when no per-date override exists (default: `10:00`) (§4.1). |
+| `TIMEZONE` | IANA timezone for cut-off time evaluation (default: `Asia/Dhaka`) (§4.1). |
+| `DEFAULT_CUTOFF_TIME` | Fallback cut-off time when no per-date override exists (default: `00:00`, midnight before the meal date) (§4.1). |
 | `INTERNAL_API_KEY` | Bearer token required by the backend REST API endpoints consumed by the dashboard (§5.5). |
 
 > In this iteration, these variables are set manually in the Lambda console or a local `.env` file. IaC-managed Secrets Manager integration is deferred to a future iteration.
@@ -234,28 +234,29 @@ The cut-off time is the daily deadline after which no more meal changes are acce
 
 **Default behaviour:**
 
-- The default cut-off is **10:00 AM** on the day of the meal (same-day changes allowed up to that point).
-- All times are evaluated in the **server's local timezone**, configurable via the `TIMEZONE` environment variable (default: `Asia/Kuala_Lumpur`).
+- The default cut-off is **12:00 AM (00:00) midnight before the meal date** — logistics needs the headcount estimate before early-morning.
+- All times are evaluated in the **server's local timezone**, configurable via the `TIMEZONE` environment variable (default: `Asia/Dhaka`).
 
 **Cut-off enforcement logic:**
 
 ```text
 now = current datetime in configured timezone
 target_date = date the user is trying to update
+cutoff_datetime = (target_date - 1 day) at cut_off_time
 
-if target_date < today:
-    → reject: "Cannot update records for a past date."
+if target_date <= today:
+    → reject: "Cannot update records for today or a past date."
 
-if target_date == today AND now.time() >= cut_off_time:
-    → reject: "Cut-off time has passed for today. Changes are no longer accepted."
+if now >= cutoff_datetime:
+    → reject: "Cut-off time has passed for {target_date}. Changes are no longer accepted."
 
-if target_date > today:
-    → allow: future dates are always open for updates.
+if now < cutoff_datetime:
+    → allow: cut-off has not yet been reached.
 ```
 
 **Admin override:** Users with the `@Admin` / `@Logistics` role can bypass the cut-off check entirely. This allows last-minute corrections without a time gate.
 
-**Cut-off time storage:** The cut-off time for a given date is stored in the `mhp-cutoff-config` table as a single item keyed by `date`. If no record exists for a date, the system falls back to the `DEFAULT_CUTOFF_TIME` environment variable (default: `10:00`).
+**Cut-off time storage:** The cut-off time for a given date is stored in the `mhp-cutoff-config` table as a single item keyed by `date` (the meal date). If no record exists for a date, the system falls back to the `DEFAULT_CUTOFF_TIME` environment variable (default: `00:00`).
 
 ---
 
@@ -311,13 +312,8 @@ The system does **not** require every employee to explicitly opt in — absence 
 /
 ├── app/
 │   ├── __init__.py
-│   ├── main.py               # FastAPI app factory + Mangum handler entry point
+│   ├── handler.py            # Lambda entry point — signature verification + command routing
 │   ├── config.py             # Pydantic Settings class (env var management)
-│   │
-│   ├── api/                  # FastAPI routers (HTTP layer only)
-│   │   ├── __init__.py
-│   │   ├── interactions.py   # POST /interactions — Discord webhook entry point
-│   │   └── health.py         # GET /health — Lambda warm-up / ALB health check
 │   │
 │   ├── services/             # Business logic and DynamoDB interactions
 │   │   ├── __init__.py
@@ -344,9 +340,8 @@ The system does **not** require every employee to explicitly opt in — absence 
 
 | Module | Responsibility |
 | --- | --- |
-| `app/main.py` | Creates the FastAPI app, registers routers, wraps with `Mangum` for Lambda. |
+| `app/handler.py` | Lambda entry point (`handler(event, context)`). Verifies Ed25519 signature, parses the interaction payload, and dispatches to the correct service function by command name. Returns a JSON-serialisable dict to API Gateway. |
 | `app/config.py` | Defines `Settings(BaseSettings)` — single source of truth for all env vars. |
-| `app/api/interactions.py` | Receives raw Discord POST, runs signature verification dependency, dispatches to the correct command handler. |
 | `app/services/meal_service.py` | Implements cut-off time logic, opt-in/out writes, event meal state transitions. |
 | `app/services/headcount_service.py` | Queries DynamoDB for daily/team summaries; computes event day expected counts. |
 | `app/services/discord_service.py` | Sends deferred follow-up messages to Discord via REST after Lambda responds. |
@@ -357,9 +352,6 @@ The system does **not** require every employee to explicitly opt in — absence 
 
 | Package | Purpose |
 | --- | --- |
-| `fastapi` | Web framework — routing, dependency injection, request parsing. |
-| `uvicorn` | ASGI server for local development. Not used in Lambda. |
-| `mangum` | Wraps the FastAPI ASGI app to handle AWS Lambda + API Gateway proxy events. |
 | `boto3` | AWS SDK — DynamoDB client for all read/write operations. |
 | `pydantic` | Data validation and serialisation for request/response models. |
 | `pydantic-settings` | `BaseSettings` support for environment variable loading. |
@@ -377,11 +369,11 @@ All endpoints are served under the Lambda function URL proxied through API Gatew
 | Method | Path | Auth | Description |
 | --- | --- | --- | --- |
 | `POST` | `/interactions` | Ed25519 signature (§3.1) | Receives all Discord interaction events — slash commands, buttons, select menus. |
-| `GET` | `/health` | None | Lambda warm-up and load balancer health check. |
+| `GET` | `/health` | None | Lambda warm-up and load balancer health check. Also the target for a scheduled EventBridge warm-up ping (see §7). |
 
 ### Discord Slash Commands
 
-Registered via the Discord Developer Portal. Each command maps to a handler inside `app/api/interactions.py`.
+Registered via the Discord Developer Portal. Each command maps to a handler inside `app/handler.py`.
 
 | Command | Permission | Description |
 | --- | --- | --- |
@@ -439,7 +431,8 @@ Items identified during architecture design that are intentionally queued for la
 - **CI/CD (GitHub Actions):** Automate linting, testing, packaging, and Lambda deployment on merge to `main`.
 - **AWS Secrets Manager:** Migrate `DISCORD_BOT_TOKEN` and `DISCORD_PUBLIC_KEY` from environment variables to Secrets Manager with automatic rotation.
 - **DynamoDB Streams → async processing:** Trigger a secondary Lambda on record changes to push live updates to the web dashboard without polling.
-- **Lambda Provisioned Concurrency:** Eliminate cold starts for time-sensitive cut-off enforcement if usage patterns demand it.
+- **Lambda warm-up via EventBridge (low-cost mitigation):** Schedule an EventBridge rule to `GET /health` every 5 minutes during the evening submission window (e.g., 19:00–23:59 local time, leading up to the 00:00 cut-off). This keeps the container warm before the peak usage period at negligible cost (~$0/month within free tier). Does not guarantee zero cold starts but eliminates them during the scheduled window. No code changes required — only an EventBridge rule and IAM permission to invoke the function URL.
+- **Lambda Provisioned Concurrency (full elimination):** Reserve a minimum number of pre-initialized execution environments. Eliminates cold starts entirely but incurs a fixed hourly cost; appropriate only if warm-up pings prove insufficient or if SLA requirements tighten.
 - **Structured logging (AWS Powertools):** Replace raw `print`/`logging` calls with `aws_lambda_powertools` for structured JSON logs, tracing (X-Ray), and metrics.
 - **Rate limiting:** Add per-user request throttling at the API Gateway level to prevent abuse.
 
@@ -449,10 +442,8 @@ Items identified during architecture design that are intentionally queued for la
 
 | Resource | URL |
 | --- | --- |
-| FastAPI Documentation | <https://fastapi.tiangolo.com/> |
 | Discord Interactions API | <https://discord.com/developers/docs/interactions/receiving-and-responding> |
 | Discord Security — Request Verification | <https://discord.com/developers/docs/interactions/receiving-and-responding#security-and-authorization> |
-| Mangum (ASGI → Lambda adapter) | <https://mangum.fastapiexpert.com/> |
 | AWS Lambda — Graviton2 | <https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2/> |
 | DynamoDB Single-Table Design | <https://www.alexdebrie.com/posts/dynamodb-single-table/> |
 | PyNaCl Documentation | <https://pynacl.readthedocs.io/> |

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -377,9 +377,7 @@ Registered via the Discord Developer Portal. Each command maps to a handler insi
 | `/meal summary-all <date>` | Admin | Show org-wide headcount summary for a date. |
 | `/meal override <user> <date>` | Admin | Override any employee's meal record. |
 | `/meal event announce <date>` | Admin | Broadcast the event meal announcement for a pre-configured event day. |
-| `/special-day set <date> <type> [note]` | Admin / Logistics | Mark a date as a special day (e.g., event meal, holiday) with an optional note. |
-| `/special-day remove <date>` | Admin / Logistics | Remove the special-day designation from a date. |
-| `/special-day view <date>` | Admin / Logistics | View the special-day configuration for a specific date. |
+| `/special-day view <date>` | Admin / Logistics | View the special-day configuration for a specific date (read-only; days are configured statically). |
 
 ### Backend REST API Endpoints
 

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -324,3 +324,48 @@ python-dotenv>=1.0.0
 | `pydantic-settings` | `BaseSettings` support for environment variable loading. |
 | `pynacl` | Ed25519 signature verification for Discord request authentication. |
 | `python-dotenv` | Loads `.env` file during local development (no-op in Lambda). |
+
+---
+
+## 6. Out of Scope for This Iteration
+
+The following are explicitly deferred and must not be implemented until a subsequent iteration:
+
+| Item | Reason for Deferral |
+| --- | --- |
+| Infrastructure as Code (IaC) | Terraform / CDK configuration requires a stable, tested application before provisioning. |
+| CI/CD pipeline | GitHub Actions deployment workflow depends on IaC being in place first. |
+| AWS Secrets Manager integration | Env vars managed manually for now; Secrets Manager adds operational complexity before the app is validated. |
+| DynamoDB table creation | Table will be provisioned manually or via IaC in a future iteration. |
+| Discord slash command registration | Commands will be registered manually via the Discord Developer Portal in this iteration. |
+| Automated tests | Unit and integration test scaffolding is deferred until the core service layer is stable. |
+| Web dashboard changes | Dashboard updates are tracked separately under the FE track of this sprint. |
+
+---
+
+## 7. Future Work
+
+Items identified during architecture design that are intentionally queued for later iterations:
+
+- **IaC (Terraform/CDK):** Define all AWS resources (API Gateway, Lambda, DynamoDB, IAM roles) as code for reproducible deployments.
+- **CI/CD (GitHub Actions):** Automate linting, testing, packaging, and Lambda deployment on merge to `main`.
+- **AWS Secrets Manager:** Migrate `DISCORD_BOT_TOKEN` and `DISCORD_PUBLIC_KEY` from environment variables to Secrets Manager with automatic rotation.
+- **DynamoDB Streams → async processing:** Trigger a secondary Lambda on record changes to push live updates to the web dashboard without polling.
+- **Lambda Provisioned Concurrency:** Eliminate cold starts for time-sensitive cut-off enforcement if usage patterns demand it.
+- **Structured logging (AWS Powertools):** Replace raw `print`/`logging` calls with `aws_lambda_powertools` for structured JSON logs, tracing (X-Ray), and metrics.
+- **Rate limiting:** Add per-user request throttling at the API Gateway level to prevent abuse.
+
+---
+
+## 8. References
+
+| Resource | URL |
+| --- | --- |
+| FastAPI Documentation | <https://fastapi.tiangolo.com/> |
+| Discord Interactions API | <https://discord.com/developers/docs/interactions/receiving-and-responding> |
+| Discord Security — Request Verification | <https://discord.com/developers/docs/interactions/receiving-and-responding#security-and-authorization> |
+| Mangum (ASGI → Lambda adapter) | <https://mangum.fastapiexpert.com/> |
+| AWS Lambda — Graviton2 | <https://aws.amazon.com/blogs/aws/aws-lambda-functions-powered-by-aws-graviton2/> |
+| DynamoDB Single-Table Design | <https://www.alexdebrie.com/posts/dynamodb-single-table/> |
+| PyNaCl Documentation | <https://pynacl.readthedocs.io/> |
+| Pydantic Settings | <https://docs.pydantic.dev/latest/concepts/pydantic_settings/> |

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -28,3 +28,69 @@ This specification covers:
 - Security model for Discord webhook validation and role-based authorization.
 - Feature logic for Dynamic Cut-off Time and Event Meal workflows.
 - Python project structure and dependency definitions.
+
+---
+
+## 2. Proposed AWS Architecture
+
+> **Note:** Infrastructure as Code (IaC) and CI/CD pipelines are out of scope for this iteration. This section documents the target architecture to guide future provisioning.
+
+### 2.1 Serverless Request Flow
+
+```text
+Discord User
+     │
+     │  Slash Command / Interaction
+     ▼
+Discord API
+     │
+     │  HTTP POST (signed webhook)
+     ▼
+API Gateway (HTTP API)
+     │
+     │  Proxy integration
+     ▼
+AWS Lambda (FastAPI via Mangum)
+     │
+     ├──► DynamoDB (read / write meal records)
+     │
+     └──► Discord API (send follow-up response)
+```
+
+1. A Discord user triggers a slash command or button interaction.
+2. Discord sends a signed HTTP POST to the **API Gateway HTTP API** endpoint.
+3. API Gateway proxies the raw request (including signature headers) to a single **Lambda function**.
+4. The Lambda runs a **FastAPI** application adapted by **Mangum**, which:
+   - Validates the Ed25519 signature (reject immediately if invalid).
+   - Parses the interaction payload and routes it to the appropriate handler.
+   - Reads from / writes to **DynamoDB**.
+   - Returns a JSON response to Discord (or defers and sends a follow-up).
+
+### 2.2 Service Selection & Cost Rationale
+
+| Service | Tier / Config | Rationale |
+| --- | --- | --- |
+| **API Gateway** | HTTP API | ~70% cheaper than REST API; sufficient for webhook proxy with no transformation needs. |
+| **AWS Lambda** | `arm64` (Graviton2), 512 MB | Graviton2 offers ~20% better price-performance vs x86. Cold starts are acceptable for low-frequency internal tooling. |
+| **DynamoDB** | On-Demand capacity | No provisioned capacity cost at rest; scales automatically with usage spikes (e.g., morning headcount updates). |
+| **CloudWatch Logs** | Default retention (7 days) | Sufficient for operational debugging without long-term storage cost. |
+
+### 2.3 DynamoDB Data Model (Proposed)
+
+**Table: `mhp-meal-records`**
+
+| Attribute | Type | Role |
+| --- | --- | --- |
+| `PK` | `String` | Partition key — `USER#{discord_user_id}` |
+| `SK` | `String` | Sort key — `DATE#{YYYY-MM-DD}` |
+| `meal_opt_in` | `Boolean` | Whether the user is having a meal that day. |
+| `work_location` | `String` | `OFFICE` or `WFH`. |
+| `meal_type` | `String` | e.g., `STANDARD`, `VEGETARIAN`. |
+| `updated_at` | `String` | ISO 8601 timestamp of last change. |
+| `updated_by` | `String` | Discord user ID of who made the change (self or admin). |
+
+**Access patterns:**
+
+- Get a single user's record for a date → `PK + SK` (direct lookup).
+- Get all records for a date → GSI on `SK` (date-based fan-out).
+- Get all records for a team on a date → GSI on `SK` filtered by team attribute.

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -94,3 +94,70 @@ AWS Lambda (FastAPI via Mangum)
 - Get a single user's record for a date → `PK + SK` (direct lookup).
 - Get all records for a date → GSI on `SK` (date-based fan-out).
 - Get all records for a team on a date → GSI on `SK` filtered by team attribute.
+
+---
+
+## 3. Security Model
+
+### 3.1 Request Authentication — Discord Ed25519 Signature Validation
+
+Every request from Discord includes two headers that must be validated **before any business logic executes**:
+
+| Header | Description |
+| --- | --- |
+| `X-Signature-Ed25519` | Hex-encoded Ed25519 signature of the raw request body. |
+| `X-Signature-Timestamp` | Unix timestamp included in the signed message to prevent replay attacks. |
+
+**Validation algorithm:**
+
+1. Concatenate `timestamp + raw_body` as bytes.
+2. Verify the signature against Discord's public key using `pynacl` (`nacl.signing.VerifyKey`).
+3. If verification fails → return `HTTP 401` immediately, no further processing.
+4. If the timestamp is more than 5 minutes old → return `HTTP 401` (replay attack protection).
+
+This check runs as a FastAPI dependency, applied globally to all interaction endpoints.
+
+```python
+# Pseudocode — implementation detail, not production code
+def verify_discord_signature(
+    signature: str,  # from X-Signature-Ed25519
+    timestamp: str,  # from X-Signature-Timestamp
+    body: bytes,
+    public_key: str,  # DISCORD_PUBLIC_KEY env var
+) -> None:
+    message = timestamp.encode() + body
+    verify_key = VerifyKey(bytes.fromhex(public_key))
+    verify_key.verify(message, bytes.fromhex(signature))
+    # raises nacl.exceptions.BadSignatureError on failure
+```
+
+### 3.2 Authorization — Discord Role-Based Access Control
+
+Authorization is enforced at the command handler level based on the Discord roles present in the interaction payload (`member.roles`). No external role store is needed; Discord's role system is the source of truth.
+
+| Role | Permission Level | Allowed Actions |
+| --- | --- | --- |
+| `@everyone` (Employee) | Standard | Update own meal opt-in, update own work location, view own status. |
+| `@Team Lead` | Elevated | All employee actions + view team headcount summary for any date. |
+| `@Admin` / `@Logistics` | Full | All team lead actions + view org-wide summary, override any employee's record. |
+
+**Authorization flow:**
+
+1. Extract `member.roles` from the validated interaction payload.
+2. Match against configured role IDs (stored as environment variables, e.g., `ROLE_TEAM_LEAD_ID`, `ROLE_ADMIN_ID`).
+3. If the user's roles do not satisfy the required permission level for the invoked command → return an ephemeral error message (visible only to the user).
+
+### 3.3 Environment Variable Management
+
+Sensitive configuration is managed via a `Settings` class (Pydantic `BaseSettings`), loading values from environment variables. No secrets are hardcoded.
+
+| Variable | Description |
+| --- | --- |
+| `DISCORD_PUBLIC_KEY` | Discord application's Ed25519 public key for signature verification. |
+| `DISCORD_BOT_TOKEN` | Bot token for sending follow-up messages via Discord REST API. |
+| `DYNAMODB_TABLE_NAME` | DynamoDB table name (defaults to `mhp-meal-records`). |
+| `AWS_REGION` | AWS region for DynamoDB client (defaults to `ap-southeast-1`). |
+| `ROLE_TEAM_LEAD_ID` | Discord role ID for Team Lead permission level. |
+| `ROLE_ADMIN_ID` | Discord role ID for Admin/Logistics permission level. |
+
+> In this iteration, these variables are set manually in the Lambda console or a local `.env` file. IaC-managed Secrets Manager integration is deferred to a future iteration.

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -1,0 +1,30 @@
+# Meal Headcount Planner — Discord Bot Integration
+
+**Version:** 1.0    
+**Date:** 2026-03-02    
+**Status:** Draft    
+
+---
+
+## 1. Overview
+
+### 1.1 Purpose
+
+This document defines the technical architecture, security model, and feature scope for integrating a Discord bot into the Meal Headcount Planner (MHP) system. It serves as the authoritative reference for implementation decisions during Task 2 and guides future infrastructure provisioning.
+
+### 1.2 Project Summary
+
+The Meal Headcount Planner (MHP) is an internal tool that helps kitchen/logistics teams accurately predict daily meal counts. Task 2 evolves the system from a standalone web tool into a production-grade platform by adding:
+
+- A **Discord bot** as a self-service input channel for employees.
+- A **serverless AWS backend** using Lambda, API Gateway, and DynamoDB.
+- A **structured web dashboard** with real-time updates and component-based UI.
+
+### 1.3 Scope of This Document
+
+This specification covers:
+
+- Proposed AWS serverless architecture (not yet deployed via IaC).
+- Security model for Discord webhook validation and role-based authorization.
+- Feature logic for Dynamic Cut-off Time and Event Meal workflows.
+- Python project structure and dependency definitions.

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -25,9 +25,11 @@ The Meal Headcount Planner (MHP) is an internal tool that helps kitchen/logistic
 This specification covers:
 
 - Proposed AWS serverless architecture (not yet deployed via IaC).
-- Security model for Discord webhook validation and role-based authorization.
+- Cost optimization decisions for each AWS service.
+- Security model for Discord webhook validation, user identity, and role-based authorization.
 - Feature logic for Dynamic Cut-off Time and Event Meal workflows.
-- Python project structure and dependency definitions.
+- Python project structure, module responsibilities, and dependency definitions.
+- API endpoint definitions for both Discord interactions and the backend REST API.
 
 ---
 
@@ -66,14 +68,17 @@ AWS Lambda (FastAPI via Mangum)
    - Reads from / writes to **DynamoDB**.
    - Returns a JSON response to Discord (or defers and sends a follow-up).
 
-### 2.2 Service Selection & Cost Rationale
+### 2.2 Service Selection & Cost Optimization
 
-| Service | Tier / Config | Rationale |
-| --- | --- | --- |
-| **API Gateway** | HTTP API | ~70% cheaper than REST API; sufficient for webhook proxy with no transformation needs. |
-| **AWS Lambda** | `arm64` (Graviton2), 512 MB | Graviton2 offers ~20% better price-performance vs x86. Cold starts are acceptable for low-frequency internal tooling. |
-| **DynamoDB** | On-Demand capacity | No provisioned capacity cost at rest; scales automatically with usage spikes (e.g., morning headcount updates). |
-| **CloudWatch Logs** | Default retention (7 days) | Sufficient for operational debugging without long-term storage cost. |
+All service choices minimize cost for low-to-medium usage internal tooling with no guaranteed baseline traffic.
+
+| Service | Tier / Config | Cost Decision | Impact |
+| --- | --- | --- | --- |
+| **API Gateway** | HTTP API | HTTP API over REST API | ~70% cheaper per request; REST-only features (transformation, usage plans) are not needed. |
+| **AWS Lambda** | `arm64` (Graviton2), 512 MB | Graviton2 architecture | ~20% lower compute cost vs x86 at identical memory/duration. Cold starts acceptable for low-frequency tooling. |
+| **AWS Lambda** | Single function | One function for all routes via FastAPI + Mangum | Eliminates overhead of managing and cold-starting multiple per-route functions. |
+| **DynamoDB** | On-Demand capacity | No provisioned capacity | Zero cost at rest; scales automatically with bursty morning headcount traffic. |
+| **CloudWatch Logs** | 7-day retention | Minimal log retention | Prevents unbounded storage accumulation; sufficient for operational debugging. |
 
 ### 2.3 DynamoDB Data Model (Proposed)
 
@@ -159,8 +164,37 @@ Sensitive configuration is managed via a `Settings` class (Pydantic `BaseSetting
 | `AWS_REGION` | AWS region for DynamoDB client (defaults to `ap-southeast-1`). |
 | `ROLE_TEAM_LEAD_ID` | Discord role ID for Team Lead permission level. |
 | `ROLE_ADMIN_ID` | Discord role ID for Admin/Logistics permission level. |
+| `AUTHORIZED_GUILD_ID` | Discord guild (server) ID — interactions from other guilds are rejected (§3.4). |
+| `TIMEZONE` | IANA timezone for cut-off time evaluation (default: `Asia/Kuala_Lumpur`) (§4.1). |
+| `DEFAULT_CUTOFF_TIME` | Fallback cut-off time when no per-date override exists (default: `10:00`) (§4.1). |
+| `INTERNAL_API_KEY` | Bearer token required by the backend REST API endpoints consumed by the dashboard (§5.5). |
 
 > In this iteration, these variables are set manually in the Lambda console or a local `.env` file. IaC-managed Secrets Manager integration is deferred to a future iteration.
+
+### 3.4 User Identity — Discord OAuth2
+
+Discord's Interactions API embeds verified user identity directly inside the signed interaction payload. No separate OAuth2 token exchange is required for slash command interactions — the user's identity is established as part of the same request that is already validated by Ed25519 signature verification (§3.1).
+
+**Identity fields available in every interaction payload:**
+
+| Field | Path in payload | Description |
+| --- | --- | --- |
+| `user_id` | `member.user.id` | Discord's unique, immutable snowflake ID for the user. Used as the primary key in DynamoDB (`USER#{user_id}`). |
+| `username` | `member.user.username` | Display name for bot responses. Not used for authorization decisions. |
+| `roles` | `member.roles` | List of Discord role IDs assigned to the user in the guild. Drives RBAC (§3.2). |
+| `guild_id` | `guild_id` | Confirms the interaction originates from the authorized guild. Requests from other guilds are rejected. |
+
+**Why no separate OAuth2 flow is needed:**
+
+Discord OAuth2 is required when a third-party app needs to act on behalf of a user outside of a guild interaction (e.g., access a user's DMs, read their profile). For slash command bots operating within a guild:
+
+- Discord authenticates the user when they invoke the command.
+- The signed payload (verified in §3.1) guarantees the identity fields have not been tampered with.
+- The `user_id` extracted from the payload is therefore trustworthy without any additional token exchange.
+
+**Guild authorization guard:**
+
+On every interaction, the handler verifies that `guild_id` matches the `AUTHORIZED_GUILD_ID` environment variable. Interactions from unauthorized guilds are rejected with `HTTP 401` before any business logic runs.
 
 ---
 
@@ -316,7 +350,7 @@ The system does **not** require every employee to explicitly opt in — absence 
 
 ---
 
-## 5.5 API Endpoints
+### 5.5 API Endpoints
 
 All endpoints are served under the Lambda function URL proxied through API Gateway.
 

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -243,3 +243,84 @@ The system does **not** require every employee to explicitly opt in — absence 
 | Regular day | `meal_opt_in = false` | Opt in | `meal_opt_in = true` |
 | Event meal day | Implicit opt-in (no record) | Opt out | `meal_opt_in = false` |
 | Event meal day | `meal_opt_in = false` | Re-opt in (before deadline) | Record deleted (returns to implicit opt-in) |
+
+---
+
+## 5. Python Project Structure
+
+### 5.1 Runtime
+
+- **Python version:** 3.11 (minimum). Required for optimal Lambda cold-start performance and full `tomllib` / `typing` support.
+- **Lambda runtime:** `python3.11` on `arm64` (Graviton2).
+
+### 5.2 Directory Layout
+
+```text
+/
+├── app/
+│   ├── __init__.py
+│   ├── main.py               # FastAPI app factory + Mangum handler entry point
+│   ├── config.py             # Pydantic Settings class (env var management)
+│   │
+│   ├── api/                  # FastAPI routers (HTTP layer only)
+│   │   ├── __init__.py
+│   │   ├── interactions.py   # POST /interactions — Discord webhook entry point
+│   │   └── health.py         # GET /health — Lambda warm-up / ALB health check
+│   │
+│   ├── services/             # Business logic and DynamoDB interactions
+│   │   ├── __init__.py
+│   │   ├── meal_service.py   # Meal opt-in/out, cut-off enforcement, event meals
+│   │   ├── headcount_service.py  # Headcount aggregation and summary generation
+│   │   └── discord_service.py    # Discord REST API calls (follow-up messages)
+│   │
+│   └── models/               # Pydantic models (request/response schemas)
+│       ├── __init__.py
+│       ├── discord_models.py # Discord interaction payload schemas
+│       └── meal_models.py    # Meal record, event, and cut-off config schemas
+│
+├── docs/
+│   ├── technical_spec.md     # This document
+│   └── iterations/
+│       └── task-iteration1.md
+│
+├── requirements.txt          # Production dependencies
+├── requirements-dev.txt      # Development/test dependencies
+└── .env.example              # Template for local environment variables
+```
+
+### 5.3 Module Responsibilities
+
+| Module | Responsibility |
+| --- | --- |
+| `app/main.py` | Creates the FastAPI app, registers routers, wraps with `Mangum` for Lambda. |
+| `app/config.py` | Defines `Settings(BaseSettings)` — single source of truth for all env vars. |
+| `app/api/interactions.py` | Receives raw Discord POST, runs signature verification dependency, dispatches to the correct command handler. |
+| `app/services/meal_service.py` | Implements cut-off time logic, opt-in/out writes, event meal state transitions. |
+| `app/services/headcount_service.py` | Queries DynamoDB for daily/team summaries; computes event day expected counts. |
+| `app/services/discord_service.py` | Sends deferred follow-up messages to Discord via REST after Lambda responds. |
+| `app/models/discord_models.py` | Typed Pydantic models for Discord interaction payloads, member objects, and options. |
+| `app/models/meal_models.py` | Typed Pydantic models for DynamoDB records: `MealRecord`, `EventRecord`, `CutoffConfig`. |
+
+### 5.4 Dependencies (`requirements.txt`)
+
+```text
+fastapi>=0.111.0
+uvicorn[standard]>=0.29.0
+mangum>=0.17.0
+boto3>=1.34.0
+pydantic>=2.7.0
+pydantic-settings>=2.2.0
+pynacl>=1.5.0
+python-dotenv>=1.0.0
+```
+
+| Package | Purpose |
+| --- | --- |
+| `fastapi` | Web framework — routing, dependency injection, request parsing. |
+| `uvicorn` | ASGI server for local development. Not used in Lambda. |
+| `mangum` | Wraps the FastAPI ASGI app to handle AWS Lambda + API Gateway proxy events. |
+| `boto3` | AWS SDK — DynamoDB client for all read/write operations. |
+| `pydantic` | Data validation and serialisation for request/response models. |
+| `pydantic-settings` | `BaseSettings` support for environment variable loading. |
+| `pynacl` | Ed25519 signature verification for Discord request authentication. |
+| `python-dotenv` | Loads `.env` file during local development (no-op in Lambda). |

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -82,7 +82,7 @@ All service choices minimize cost for low-to-medium usage internal tooling with 
 
 ### 2.3 DynamoDB Data Model (Proposed)
 
-Three separate tables are used — one per entity type. This keeps queries simple and avoids advanced single-table patterns.
+One table per entity type (multi-table design). Cut-off time and event day configuration are handled via static settings, so only one DynamoDB table is required.
 
 ---
 
@@ -98,10 +98,23 @@ Three separate tables are used — one per entity type. This keeps queries simpl
 | `updated_at` | `String` | ISO 8601 timestamp of last change. |
 | `updated_by` | `String` | Discord user ID of who made the change (self or admin). |
 
+**GSIs:**
+
+| GSI | PK | SK | Purpose |
+| --- | --- | --- | --- |
+| `user_date_index` | `user_id` | `date` | Query all meal records for a user across dates (user history, `/meal status`). |
+| `location_date_index` | `work_location` | `date` | Query all OFFICE or WFH records for a date (location-based headcount). |
+
 **Access patterns:**
 
-- Get all records for a date → Query on `date` (partition key).
-- Get a single user's record for a date → Query on `date` + `user_id` (direct lookup, no GSI needed).
+| Operation | Pattern | Notes |
+| --- | --- | --- |
+| Get all records for a date | Query on `date` (PK) | Org-wide headcount and dashboard listing. |
+| Get one user's record for a date | GetItem on `date` + `user_id` | Direct key lookup; no GSI needed. |
+| Get a user's records across dates | Query `user_date_index` on `user_id` | Drives `/meal status` history and dashboard user view. |
+| Get OFFICE or WFH headcount for a date | Query `location_date_index` on `work_location`, filter `date` | No client-side scan needed for location filtering. |
+| Count opt-ins / opt-outs for a date | Query on `date` (PK), filter client-side | Headcount totals; acceptable for small org sizes. |
+| Create or update a user's record | PutItem on `date` + `user_id` | Covers opt-in, opt-out, location update, and admin override. |
 
 ---
 

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -161,3 +161,85 @@ Sensitive configuration is managed via a `Settings` class (Pydantic `BaseSetting
 | `ROLE_ADMIN_ID` | Discord role ID for Admin/Logistics permission level. |
 
 > In this iteration, these variables are set manually in the Lambda console or a local `.env` file. IaC-managed Secrets Manager integration is deferred to a future iteration.
+
+---
+
+## 4. Feature Specification
+
+### 4.1 Dynamic Cut-off Time
+
+The cut-off time is the daily deadline after which no more meal changes are accepted for the next working day. It is "dynamic" because it can be configured per-day rather than being a fixed global value.
+
+**Default behaviour:**
+
+- The default cut-off is **10:00 AM** on the day of the meal (same-day changes allowed up to that point).
+- All times are evaluated in the **server's local timezone**, configurable via the `TIMEZONE` environment variable (default: `Asia/Kuala_Lumpur`).
+
+**Cut-off enforcement logic:**
+
+```text
+now = current datetime in configured timezone
+target_date = date the user is trying to update
+
+if target_date < today:
+    → reject: "Cannot update records for a past date."
+
+if target_date == today AND now.time() >= cut_off_time:
+    → reject: "Cut-off time has passed for today. Changes are no longer accepted."
+
+if target_date > today:
+    → allow: future dates are always open for updates.
+```
+
+**Admin override:** Users with the `@Admin` / `@Logistics` role can bypass the cut-off check entirely. This allows last-minute corrections without a time gate.
+
+**Cut-off time storage:** The cut-off time for a given date is stored in a separate DynamoDB item:
+
+- `PK`: `CONFIG#CUTOFF`
+- `SK`: `DATE#{YYYY-MM-DD}`
+- `cutoff_time`: `HH:MM` string (24-hour format)
+
+If no record exists for a date, the system falls back to the `DEFAULT_CUTOFF_TIME` environment variable (default: `10:00`).
+
+---
+
+### 4.2 Event Meal Workflow — Opt-in by Default, Manual Opt-out
+
+An "Event Meal" is a special catering day (e.g., company anniversary, team lunch). On event days, all employees are **opted in by default** — the kitchen prepares for full headcount unless someone explicitly opts out.
+
+**Event day setup (Admin action):**
+
+1. Admin uses `/meal event set <date> <description>` to flag a date as an event meal day.
+2. The system writes an event record to DynamoDB:
+   - `PK`: `EVENT#<date>`
+   - `SK`: `META`
+   - `description`: event name/notes
+   - `opt_out_deadline`: cut-off time for that day (same rules as §4.1)
+3. The bot broadcasts a notification to the configured meal channel announcing the event and the opt-out deadline.
+
+**Employee opt-out flow:**
+
+1. Employee uses `/meal optout <date>` or clicks the "Opt Out" button in the bot's announcement message.
+2. The system checks:
+   - Is the date flagged as an event day? If not → standard opt-in/out logic applies.
+   - Has the opt-out deadline passed? If yes → reject with an ephemeral message.
+3. If valid, the employee's `meal_opt_in` field is set to `false` for that date.
+4. Bot confirms with an ephemeral reply: _"You have opted out of the event meal on {date}."_
+
+**Headcount calculation on event days:**
+
+```text
+total_opted_out  = count of records where meal_opt_in == false for that date
+expected_count   = total_active_employees - total_opted_out
+```
+
+The system does **not** require every employee to explicitly opt in — absence of an opt-out record is treated as opt-in for event days only.
+
+**State transition summary:**
+
+| Scenario | Default State | Employee Action | Resulting State |
+| --- | --- | --- | --- |
+| Regular day | `meal_opt_in = true` | Opt out | `meal_opt_in = false` |
+| Regular day | `meal_opt_in = false` | Opt in | `meal_opt_in = true` |
+| Event meal day | Implicit opt-in (no record) | Opt out | `meal_opt_in = false` |
+| Event meal day | `meal_opt_in = false` | Re-opt in (before deadline) | Record deleted (returns to implicit opt-in) |

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -377,6 +377,9 @@ Registered via the Discord Developer Portal. Each command maps to a handler insi
 | `/meal summary-all <date>` | Admin | Show org-wide headcount summary for a date. |
 | `/meal override <user> <date>` | Admin | Override any employee's meal record. |
 | `/meal event announce <date>` | Admin | Broadcast the event meal announcement for a pre-configured event day. |
+| `/special-day set <date> <type> [note]` | Admin / Logistics | Mark a date as a special day (e.g., event meal, holiday) with an optional note. |
+| `/special-day remove <date>` | Admin / Logistics | Remove the special-day designation from a date. |
+| `/special-day view <date>` | Admin / Logistics | View the special-day configuration for a specific date. |
 
 ### Backend REST API Endpoints
 

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -27,7 +27,7 @@ This specification covers:
 - Proposed AWS serverless architecture (not yet deployed via IaC).
 - Cost optimization decisions for each AWS service.
 - Security model for Discord webhook validation, user identity, and role-based authorization.
-- Feature logic for Dynamic Cut-off Time and Event Meal workflows.
+- Feature logic for cut-off time enforcement and Event Meal workflows.
 - Python project structure, module responsibilities, and dependency definitions.
 - API endpoint definitions for both Discord interactions and the backend REST API.
 
@@ -105,29 +105,6 @@ Three separate tables are used — one per entity type. This keeps queries simpl
 
 ---
 
-**Table: `mhp-cutoff-config`**
-
-| Attribute | Type | Role |
-| --- | --- | --- |
-| `date` | `String` | Partition key — `YYYY-MM-DD` |
-| `cutoff_time` | `String` | Cut-off time in `HH:MM` (24-hour) format. |
-
-**Access pattern:** Get cut-off time for a date → GetItem on `date`.
-
----
-
-**Table: `mhp-events`**
-
-| Attribute | Type | Role |
-| --- | --- | --- |
-| `date` | `String` | Partition key — `YYYY-MM-DD` |
-| `description` | `String` | Event name or notes. |
-| `opt_out_deadline` | `String` | Cut-off time for opt-out in `HH:MM` format. |
-
-**Access pattern:** Check if a date is an event day → GetItem on `date`. Returns nothing if not an event day.
-
----
-
 ## 3. Security Model
 
 ### 3.1 Request Authentication — Discord Ed25519 Signature Validation
@@ -187,14 +164,12 @@ Sensitive configuration is managed via a `Settings` class (Pydantic `BaseSetting
 | `DISCORD_PUBLIC_KEY` | Discord application's Ed25519 public key for signature verification. |
 | `DISCORD_BOT_TOKEN` | Bot token for sending follow-up messages via Discord REST API. |
 | `DYNAMODB_MEAL_TABLE` | Meal records table name (defaults to `mhp-meal-records`). |
-| `DYNAMODB_CUTOFF_TABLE` | Cut-off config table name (defaults to `mhp-cutoff-config`). |
-| `DYNAMODB_EVENTS_TABLE` | Event meal table name (defaults to `mhp-events`). |
 | `AWS_REGION` | AWS region for DynamoDB client (defaults to `ap-southeast-1`). |
 | `ROLE_TEAM_LEAD_ID` | Discord role ID for Team Lead permission level. |
 | `ROLE_ADMIN_ID` | Discord role ID for Admin/Logistics permission level. |
 | `AUTHORIZED_GUILD_ID` | Discord guild (server) ID — interactions from other guilds are rejected (§3.4). |
 | `TIMEZONE` | IANA timezone for cut-off time evaluation (default: `Asia/Dhaka`) (§4.1). |
-| `DEFAULT_CUTOFF_TIME` | Fallback cut-off time when no per-date override exists (default: `00:00`, midnight before the meal date) (§4.1). |
+| `DEFAULT_CUTOFF_TIME` | Static cut-off time applied to every working day (default: `00:00`, midnight before the meal date) (§4.1). |
 | `INTERNAL_API_KEY` | Bearer token required by the backend REST API endpoints consumed by the dashboard (§5.5). |
 
 > In this iteration, these variables are set manually in the Lambda console or a local `.env` file. IaC-managed Secrets Manager integration is deferred to a future iteration.
@@ -228,21 +203,18 @@ On every interaction, the handler verifies that `guild_id` matches the `AUTHORIZ
 
 ## 4. Feature Specification
 
-### 4.1 Dynamic Cut-off Time
+### 4.1 Cut-off Time
 
-The cut-off time is the daily deadline after which no more meal changes are accepted for the next working day. It is "dynamic" because it can be configured per-day rather than being a fixed global value.
+The cut-off time is the daily deadline after which no more meal changes are accepted for the next working day. It is a single static value applied uniformly to every working day, configured via the `DEFAULT_CUTOFF_TIME` environment variable (default: `00:00`, midnight before the meal date).
 
-**Default behaviour:**
-
-- The default cut-off is **12:00 AM (00:00) midnight before the meal date** — logistics needs the headcount estimate before early-morning.
-- All times are evaluated in the **server's local timezone**, configurable via the `TIMEZONE` environment variable (default: `Asia/Dhaka`).
+All times are evaluated in the **server's local timezone**, configurable via the `TIMEZONE` environment variable (default: `Asia/Dhaka`).
 
 **Cut-off enforcement logic:**
 
 ```text
 now = current datetime in configured timezone
 target_date = date the user is trying to update
-cutoff_datetime = (target_date - 1 day) at cut_off_time
+cutoff_datetime = (target_date - 1 day) at DEFAULT_CUTOFF_TIME
 
 if target_date <= today:
     → reject: "Cannot update records for today or a past date."
@@ -256,19 +228,24 @@ if now < cutoff_datetime:
 
 **Admin override:** Users with the `@Admin` / `@Logistics` role can bypass the cut-off check entirely. This allows last-minute corrections without a time gate.
 
-**Cut-off time storage:** The cut-off time for a given date is stored in the `mhp-cutoff-config` table as a single item keyed by `date` (the meal date). If no record exists for a date, the system falls back to the `DEFAULT_CUTOFF_TIME` environment variable (default: `00:00`).
-
 ---
 
 ### 4.2 Event Meal Workflow — Opt-in by Default, Manual Opt-out
 
 An "Event Meal" is a special catering day (e.g., company anniversary, team lunch). On event days, all employees are **opted in by default** — the kitchen prepares for full headcount unless someone explicitly opts out.
 
-**Event day setup (Admin action):**
+**Event day setup (static configuration):**
 
-1. Admin uses `/meal event set <date> <description>` to flag a date as an event meal day.
-2. The system writes an event record to the `mhp-events` table keyed by `date`, with `description` and `opt_out_deadline` fields (same cut-off rules as §4.1).
-3. The bot broadcasts a notification to the configured meal channel announcing the event and the opt-out deadline.
+Event days are defined in a static configuration file (`config/events.json`) bundled with the Lambda deployment package. Each entry specifies a date and description. The opt-out deadline follows the same `DEFAULT_CUTOFF_TIME` rule as regular days (§4.1) — no separate per-event deadline is needed.
+
+```json
+[
+  { "date": "2026-03-15", "description": "Company anniversary lunch" },
+  { "date": "2026-06-01", "description": "Mid-year team lunch" }
+]
+```
+
+To add or modify event days, update `config/events.json` and redeploy the Lambda function. The bot can broadcast a one-time notification via a manual `/meal event announce <date>` command (Admin only), or the message can be posted manually.
 
 **Employee opt-out flow:**
 
@@ -295,7 +272,7 @@ The system does **not** require every employee to explicitly opt in — absence 
 | Regular day | `meal_opt_in = true` | Opt out | `meal_opt_in = false` |
 | Regular day | `meal_opt_in = false` | Opt in | `meal_opt_in = true` |
 | Event meal day | Implicit opt-in (no record) | Opt out | `meal_opt_in = false` |
-| Event meal day | `meal_opt_in = false` | Re-opt in (before deadline) | Record deleted (returns to implicit opt-in) |
+| Event meal day | `meal_opt_in = false` | Re-opt in (before deadline) | `meal_opt_in = true` |
 
 ---
 
@@ -326,6 +303,9 @@ The system does **not** require every employee to explicitly opt in — absence 
 │       ├── discord_models.py # Discord interaction payload schemas
 │       └── meal_models.py    # Meal record, event, and cut-off config schemas
 │
+├── config/
+│   └── events.json           # Static list of event meal dates and descriptions
+│
 ├── docs/
 │   ├── technical_spec.md     # This document
 │   └── iterations/
@@ -346,7 +326,7 @@ The system does **not** require every employee to explicitly opt in — absence 
 | `app/services/headcount_service.py` | Queries DynamoDB for daily/team summaries; computes event day expected counts. |
 | `app/services/discord_service.py` | Sends deferred follow-up messages to Discord via REST after Lambda responds. |
 | `app/models/discord_models.py` | Typed Pydantic models for Discord interaction payloads, member objects, and options. |
-| `app/models/meal_models.py` | Typed Pydantic models for DynamoDB records: `MealRecord`, `EventRecord`, `CutoffConfig`. |
+| `app/models/meal_models.py` | Typed Pydantic models for DynamoDB records: `MealRecord`. Also includes `EventConfig` for deserialising `config/events.json`. |
 
 ### 5.4 Dependencies (`requirements.txt`)
 
@@ -383,8 +363,7 @@ Registered via the Discord Developer Portal. Each command maps to a handler insi
 | `/meal summary <date>` | Team Lead | Show team headcount summary for a date. |
 | `/meal summary-all <date>` | Admin | Show org-wide headcount summary for a date. |
 | `/meal override <user> <date>` | Admin | Override any employee's meal record. |
-| `/meal cutoff set <date> <time>` | Admin | Set a custom cut-off time for a specific date. |
-| `/meal event set <date> <desc>` | Admin | Flag a date as an event meal day and broadcast announcement. |
+| `/meal event announce <date>` | Admin | Broadcast the event meal announcement for a pre-configured event day. |
 
 ### Backend REST API Endpoints
 
@@ -395,15 +374,8 @@ Consumed by the web dashboard frontend, served under `/api/v1`. All require `Aut
 | `GET` | `/api/v1/meals/{date}` | Admin / Team Lead | Get all meal records for a date. Supports `?team_id=` filter. |
 | `GET` | `/api/v1/meals/{date}/{user_id}` | Admin / Team Lead | Get a single user's meal record for a date. |
 | `PUT` | `/api/v1/meals/{date}/{user_id}` | Admin | Create or update a meal record for a user on a date. |
-| `DELETE` | `/api/v1/meals/{date}/{user_id}` | Admin | Delete a meal record (resets to implicit opt-in on event days). |
 | `GET` | `/api/v1/headcount/{date}` | Admin | Org-wide headcount summary for a date. |
 | `GET` | `/api/v1/headcount/{date}/teams/{team_id}` | Team Lead | Team-level headcount summary for a date. |
-| `GET` | `/api/v1/config/cutoff/{date}` | Admin | Get the cut-off time for a specific date. |
-| `PUT` | `/api/v1/config/cutoff/{date}` | Admin | Set or override the cut-off time for a specific date. |
-| `DELETE` | `/api/v1/config/cutoff/{date}` | Admin | Remove override — reverts to `DEFAULT_CUTOFF_TIME`. |
-| `GET` | `/api/v1/events/{date}` | Admin / Team Lead | Get event meal details for a date. Returns `404` if not an event day. |
-| `POST` | `/api/v1/events` | Admin | Create a new event meal day. |
-| `DELETE` | `/api/v1/events/{date}` | Admin | Remove event meal flag from a date. |
 
 ---
 


### PR DESCRIPTION
<!-- Link to the issue this PR addresses -->
Fixes #44 

## Dependencies

_(none needed)_

## What does this PR do?

Adds the full technical specification document for integrating a Discord bot into the Meal Headcount Planner system.

## Type of Change

- [x] Documentation

## What was changed

Created `docs/technical_spec.md` covering:

- **AWS serverless architecture** — API Gateway (HTTP API) → Lambda (plain handler, arm64, SnapStart) → DynamoDB, with cost rationale for each service choice.
- **DynamoDB data model** — Single `mhp-meal-records` table with two GSIs (`user_date_index`, `location_date_index`). Cut-off time and event-day configuration are static (env var + bundled JSON), so no additional tables are needed.
- **Security model** — Discord Ed25519 signature validation, role-based access control via Discord guild roles, guild ID guard, and env var management via Pydantic `BaseSettings`.
- **Feature specs** — Static cut-off time enforcement (via `DEFAULT_CUTOFF_TIME` env var) and Event Meal opt-in-by-default / opt-out workflow (event days defined in `config/events.json`).
- **Python project structure** — Directory layout (including `config/events.json`), module responsibilities, and dependency list.
- **API surface** — Discord slash commands (including read-only `/special-day view`) and backend REST API endpoints.
- **Out of scope / Future work** — Explicit deferral list (IaC, CI/CD, Secrets Manager, automated tests).

## Changelog

None: internal documentation only, not user visible.

## How to Test

1. Open `docs/technical_spec.md` and review each section for completeness.
2. Verify the single `mhp-meal-records` table design (including the two GSIs) matches the access patterns described.
3. Confirm all environment variables in §3.3 are consistent with their references throughout the document (note: `DYNAMODB_MEAL_TABLE` is the only table variable; cut-off and events are static config).

## How QA Should Test

Not applicable — documentation change only.

## Rollback Plan

No rollback needed — docs only.

## Checklist

- [ ] My code follows the project style guidelines
- [ ] Code passes linting and type checks
- [ ] All tests pass
- [ ] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)

## Note for Reviewer

A single `mhp-meal-records` DynamoDB table covers all runtime data. Cut-off time is a static env var (`DEFAULT_CUTOFF_TIME`) and event days are a bundled JSON file (`config/events.json`), keeping the data model simple with no additional tables. Lambda SnapStart (Python 3.12, arm64) replaces any warm-up scheduling — no provisioned concurrency or EventBridge pings needed.