### PR TITLE
[PR-4] feat: Implement Discord bot Lambda handler with security, cut-off enforcement, and meal commands (issue 2.3 & 2.4)

### DIFF
--- a/Task-2/app/models/meal_models.py
+++ b/Task-2/app/models/meal_models.py
@@ -8,7 +8,7 @@ class MealRecord(BaseModel):
     user_id: str                    # Discord snowflake — sort key
     meal_opt_in: bool = True
     work_location: str = "OFFICE"   # OFFICE | WFH
-    meal_type: str = "STANDARD"     # STANDARD | VEGETARIAN
+    meal_type: str = "LUNCH"        # LUNCH | SNACKS | IFTAR | EVENT_DINNER | OPTIONAL_DINNER
     updated_at: str = ""
     updated_by: str = ""
 
@@ -19,7 +19,7 @@ class MealRecord(BaseModel):
             user_id=item["user_id"],
             meal_opt_in=item.get("meal_opt_in", True),
             work_location=item.get("work_location", "OFFICE"),
-            meal_type=item.get("meal_type", "STANDARD"),
+            meal_type=item.get("meal_type", "LUNCH"),
             updated_at=item.get("updated_at", ""),
             updated_by=item.get("updated_by", ""),
         )

--- a/Task-2/app/services/meal_service.py
+++ b/Task-2/app/services/meal_service.py
@@ -53,9 +53,12 @@ def check_cutoff(target_date: str, bypass: bool = False) -> str | None:
         return f"Cannot update records for today or a past date."
 
     cutoff_hour, cutoff_minute = map(int, settings.default_cutoff_time.split(":"))
+    cutoff_date = target - timedelta(days=1)
     cutoff_dt = datetime(
-        target.year, target.month, target.day, cutoff_hour, cutoff_minute, tzinfo=tz
-    ) - timedelta(days=1)
+        cutoff_date.year, cutoff_date.month, cutoff_date.day,
+        cutoff_hour, cutoff_minute,
+        tzinfo=tz,
+    )
 
     if now >= cutoff_dt:
         return f"Cut-off time has passed for {target_date}. Changes are no longer accepted."

--- a/Task-2/app/services/meal_service.py
+++ b/Task-2/app/services/meal_service.py
@@ -142,6 +142,28 @@ def update_location(
     return f"Work location set to **{location}** for {date}."
 
 
+def update_meal_type(
+    date: str,
+    user_id: str,
+    meal_type: str,
+    updated_by: str,
+    bypass_cutoff: bool = False,
+) -> str:
+    meal_type = meal_type.upper()
+    if meal_type not in {"STANDARD", "VEGETARIAN"}:
+        return "Invalid meal type. Use `STANDARD` or `VEGETARIAN`."
+
+    err = check_cutoff(date, bypass=bypass_cutoff)
+    if err:
+        return err
+
+    record = get_record(date, user_id) or MealRecord(date=date, user_id=user_id)
+    record.meal_type = meal_type
+    record.updated_by = updated_by
+    upsert_record(record)
+    return f"Meal type set to **{meal_type}** for {date}."
+
+
 def get_records_for_date(date: str) -> list[MealRecord]:
     """Query mhp-meal-records by date partition key."""
     try:

--- a/Task-2/app/services/meal_service.py
+++ b/Task-2/app/services/meal_service.py
@@ -149,9 +149,10 @@ def update_meal_type(
     updated_by: str,
     bypass_cutoff: bool = False,
 ) -> str:
-    meal_type = meal_type.upper()
-    if meal_type not in {"STANDARD", "VEGETARIAN"}:
-        return "Invalid meal type. Use `STANDARD` or `VEGETARIAN`."
+    VALID_MEAL_TYPES = {"LUNCH", "SNACKS", "IFTAR", "EVENT_DINNER", "OPTIONAL_DINNER"}
+    meal_type = meal_type.upper().replace(" ", "_")
+    if meal_type not in VALID_MEAL_TYPES:
+        return f"Invalid meal type. Choose from: {', '.join(sorted(VALID_MEAL_TYPES))}."
 
     err = check_cutoff(date, bypass=bypass_cutoff)
     if err:

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -361,7 +361,7 @@ Registered via the Discord Developer Portal. Each command maps to a handler insi
 | Command | Permission | Description |
 | --- | --- | --- |
 | `/meal status [date]` | Employee | Show own meal opt-in and work location for a date (defaults to today). |
-| `/meal update` | Employee | Update own meal opt-in or work location for a date. |
+| `/meal update` | Employee | Update own meal opt-in, work location, or meal type for a date. |
 | `/meal optout <date>` | Employee | Opt out of an event meal for a specific date. |
 | `/meal summary <date>` | Team Lead | Show team headcount summary for a date. |
 | `/meal summary-all <date>` | Admin | Show org-wide headcount summary for a date. |


### PR DESCRIPTION
<!-- Link to the issue this PR addresses -->
Fixes #47 #48 

## Dependencies

- _(none needed)_

## What does this PR do?

Implements the complete Discord bot backend for the Meal Headcount Planner: Lambda request handler with Ed25519 signature verification, role-based access control, cut-off time enforcement, and the employee-facing `/meal` command family (`status`, `update`, `optout`).

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

## What was changed

**`app/handler.py` — Lambda entry point**

- Ed25519 signature verification via `pynacl` called before any routing; invalid signatures and requests with timestamps older than 5 minutes return HTTP 401.
- Guild ID guard rejects interactions from servers other than `AUTHORIZED_GUILD_ID`.
- Role helpers (`_is_admin`, `_is_team_lead`) derive permissions from `member.roles` in the signed payload — no separate OAuth2 flow.
- Full command routing for `/meal` (status, update, optout, summary, summary-all, override, event announce) and `/special-day view`.
- `/meal status` falls back to `MealRecord` defaults when no DB record exists, matching the "opted in by default" contract.
- `/meal optout` validates the target date is an event day before writing; redirects to `/meal update` otherwise.

**`app/services/meal_service.py`**

- `check_cutoff()`: timezone-aware cut-off enforcement using `zoneinfo`. Fixed a DST-unsafe calculation — date arithmetic is now performed on the naive `date` object before attaching the timezone, preventing a 1-hour drift during DST transitions.
- `opt_in()`, `opt_out()`, `update_location()`, `update_meal_type()` — all gate on `check_cutoff()` and accept `bypass_cutoff=True` for Admin overrides.
- `upsert_record()` writes through to both `mhp-meal-records` (authoritative) and `mhp-user-history` (read replica).

**`app/services/headcount_service.py`** — daily summary aggregation with event-day expected-count calculation.

**`app/services/discord_service.py`** — follow-up REST calls with `URLError` and generic exception handling.

**`app/models/`** — Pydantic models for Discord interaction payloads (`DiscordInteraction`, `DiscordMember`, `CommandOption`) and DynamoDB records (`MealRecord`, `EventConfig`) with `to_dynamo()` / `from_dynamo()` serialisation including `pk`/`sk` prefix formatting.

**`app/config.py`** — `Settings(BaseSettings)` loading all env vars; no secrets hardcoded.

**`docs/technical_spec.md`** — Updated `/meal update` command description to include `meal_type` as an updatable field.

## Changelog

```text
Feature: Discord bot Lambda handler with Ed25519 verification and guild/role-based access control
Feature: /meal status, /meal update (opt-in, location, meal type), /meal optout (event days only)
Feature: Cut-off time enforcement with timezone-aware evaluation and Admin bypass
Feature: Write-through DynamoDB persistence to mhp-meal-records and mhp-user-history
Bugfix: DST-safe cutoff datetime calculation (date subtraction before timezone attachment)
```

## How to Test

1. Copy `.env.example` to `.env` and fill in `DISCORD_PUBLIC_KEY`, `ROLE_TEAM_LEAD_ID`, `ROLE_ADMIN_ID`, `AUTHORIZED_GUILD_ID`, and stub values for `DISCORD_BOT_TOKEN`, `DYNAMODB_*`, `INTERNAL_API_KEY`.
2. Send a POST to `/interactions` with a valid Ed25519-signed payload — expect HTTP 200.
3. Send the same request with a tampered signature — expect HTTP 401.
4. Send a valid request with a timestamp more than 5 minutes old — expect HTTP 401.
5. Send a valid interaction with a `guild_id` that doesn't match `AUTHORIZED_GUILD_ID` — expect HTTP 401.
6. Invoke `/meal status` with no existing DB record — response should show opted-in defaults, not "No record found."
7. Invoke `/meal optout` on a non-event date — response should redirect to `/meal update`.
8. Invoke `/meal summary` as an Employee role — expect ephemeral permission-denied message.

## How QA Should Test

**Affected workflows:**

- Employee self-service meal updates (opt-in, opt-out, location, meal type)
- Team Lead and Admin headcount views
- Event meal opt-out flow

**Specific checks:**

1. As an Employee, run `/meal status` — verify opt-in status, work location, and meal type are returned ephemerally.
2. As an Employee, run `/meal update` with `meal_type=VEGETARIAN` for a future date before cut-off — verify the change is confirmed ephemerally.
3. As an Employee, run `/meal update` for today's date — verify a cut-off rejection is returned ephemerally.
4. As an Employee, run `/meal optout` on a non-event date — verify the redirect message to `/meal update` is returned.
5. As an Employee, run `/meal optout` on a configured event date (see `config/events.json`) — verify opt-out is accepted.
6. As a Team Lead, run `/meal summary <date>` — verify headcount summary is returned.
7. As an Employee, run `/meal summary <date>` — verify permission-denied ephemeral message.
8. As an Admin, run `/meal override` for a past date — verify the `bypass_cutoff` path succeeds.

## Rollback Plan

Revert this PR. No database schema changes are required — tables are provisioned manually and remain unaffected. The previous Lambda version can be redeployed from the console.

## Checklist

- [x] My code follows the project style guidelines
- [ ] Code passes linting and type checks
- [ ] All tests pass
- [ ] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)

## Screenshots (if applicable)

N/A — Discord bot interactions; no UI changes.

## Note for Reviewer

- The DST cutoff fix (date arithmetic before timezone attachment) is subtle — see `meal_service.py:check_cutoff()`. Worth a close look for correctness.
- `_verify_signature` catches all exceptions in its outer `try/except` by design — any unexpected failure during verification should return 401, not 500.
- `pynacl` must be present in the Lambda deployment package; confirm it is included in the layer or zip before deploying.
