### PR TITLE
Dynamodb Single table design from the Access Pattern of Task-1 and Task-2

### DIFF
--- a/DynamoDB-Task/access_patterns.md
+++ b/DynamoDB-Task/access_patterns.md
@@ -1,0 +1,62 @@
+# DynamoDB Access Patterns
+
+## User
+
+1. Get user by userId
+2. Get user by external identity (e.g., discordId, username)
+3. Get all users
+
+---
+
+## Team
+
+1. Get team by teamId
+2. Get all teams
+
+---
+
+## Meal Participation
+
+1. Get all participation records for a date (headcount — all users, one date)
+2. Get a specific user's meals for a date (users can view/opt out here)
+3. Get a specific meal record (user + date + mealType)
+4. Get a user's participation history across dates (reporting)
+5. Upsert participation record (Employees set their own Opt-In/Opt-Out preference via Discord bot)
+
+---
+
+## Work Location
+
+1. Get all location records for a date (headcount — all users, one date)
+2. Get a specific user's location for a date
+3. Get a user's location records for a month (WFH overage report)
+4. Upsert location record (Employees set their own Office/WFH status via Discord bot)
+
+---
+
+## Special Day
+
+1. Get special day for a specific date
+2. Get all special days in a month (or range)
+
+---
+
+## Headcount Summary
+
+1. Generate headcount summary for a date (reads from Participation, Work Location, Special Day, User)
+2. Get a previously generated summary for a date
+3. Store a generated summary
+
+---
+
+
+## Notes
+
+- **"Get the team a user belongs to"** — not a separate pattern. `teamId` is a field on the User record, so User #1 already returns it.
+- **"Get all members of a team"** — not a separate Team pattern. Use User #3 (get all users) and filter by `teamId` in application code.
+- **"Get all WFH employees on a date"** (with or without team scope) — covered by Work Location #1. Filter results in application code by location and optionally by `teamId`.
+- **Meal Defaults & Logic** — The default meal status is **Opt-In**. Absence of a record implies Opt-In. Users explicitly Upsert records to Opt-Out. Since deleting records is out of scope, users must Upsert a record with "Opt-In" status to switch back from Opt-Out.
+- **Role & Team Assignment** — Roles and Teams are managed externally via Discord Roles. The MHP system reads these attributes for permission logic and filtering but does not provide write/update patterns for them.
+- **Admin/Team Lead Restrictions** — Admins and Team Leads **do not** set meal preferences for users. Only users set their own meal preferences (via Discord Slash Command).
+- **Special Days / Events** — Treated as static settings for this scope. They are read-only for the application logic (Patterns #1, #2), but no write patterns are required.
+- **Settings / Configuration** — System configurations (WFH periods, Cut-offs) are treated as static/external configuration and do not require specific DB access patterns in this scope.

--- a/DynamoDB-Task/schema.md
+++ b/DynamoDB-Task/schema.md
@@ -1,6 +1,24 @@
 # DynamoDB Single-Table Schema
 
-## Table Name: `MHP_Table`
+## Table: `MHP_Table`
+
+### Key Design
+
+| Attribute | Type   | Description        |
+| --------- | ------ | ------------------ |
+| PK        | String | Partition key      |
+| SK        | String | Sort key           |
+| GSI1PK    | String | GSI1 partition key |
+| GSI1SK    | String | GSI1 sort key      |
+
+### Conventions
+
+- Keys are prefixed to namespace entities (e.g., `USER#<userId>`, `MEAL#<date>`)
+- `METADATA` as SK marks an entity's core record
+- Dates follow `YYYY-MM-DD` format
+- `#` separates prefix from value and joins composite keys (e.g., `USER#<userId>#<mealType>`)
+
+---
 
 ## User
 
@@ -12,13 +30,13 @@
 
 ### DB Schema
 
-#### User Item
+**User Item**
 
 | PK              | SK         | GSI1PK  | GSI1SK          | Attributes                                           |
 | --------------- | ---------- | ------- | --------------- | ---------------------------------------------------- |
 | `USER#<userId>` | `METADATA` | `USERS` | `USER#<userId>` | `name`, `discordId`, `username`, `teamId`, `role`, … |
 
-#### Identity Mapping Item
+**Identity Mapping Item**
 
 | PK                     | SK                     | Attributes |
 | ---------------------- | ---------------------- | ---------- |
@@ -26,19 +44,17 @@
 
 ### How Each Access Pattern Is Served
 
-| # | Pattern                       | Operation                                                                                                      |
-|---|-------------------------------|----------------------------------------------------------------------------------------------------------------|
-| 1 | Get user by userId            | `GetItem` — PK = `USER#<userId>`, SK = `METADATA`                                                             |
-| 2 | Get user by external identity | `GetItem` — PK = `EXTID#<type>#<value>`, SK = `EXTID#<type>#<value>` → returns `userId`, then fetch User item  |
-| 3 | Get all users                 | `Query GSI1` — GSI1PK = `USERS`                                                                               |
+| # | Pattern                       | Operation                                                                             |
+|---|-------------------------------|---------------------------------------------------------------------------------------|
+| 1 | Get user by userId            | `GetItem` — PK = `USER#<userId>`, SK = `METADATA`                                    |
+| 2 | Get user by external identity | `GetItem` on `EXTID#<type>#<value>` → get `userId` → then `GetItem` on the User item |
+| 3 | Get all users                 | `Query GSI1` — GSI1PK = `USERS`                                                      |
 
 ### Explanation
 
-- **`USER#<userId>`** — The `USER#` prefix namespaces user items so they don't collide with other entity types in the single table.
-- **`METADATA`** — A constant sort key indicating this is the entity's core record (as opposed to related child items).
-- **Identity Mapping Items** — Separate items for reverse lookups. For example, a user with `discordId = "abc123"` gets an extra item with PK/SK = `EXTID#discord#abc123`. This avoids needing a GSI for identity lookups — a simple two-step read (`GetItem` for the mapping → `GetItem` for the user) handles it.
-  - When a user is created, one identity-mapping item is written per external identity (e.g., one for `discord`, one for `username`).
-- **`GSI1PK = USERS`** — All user items share the same GSI1 partition key `USERS`, which allows a single `Query` on GSI1 to return every user. `GSI1SK = USER#<userId>` provides sort order and uniqueness within that partition.
+- Identity mapping items handle reverse lookups without a GSI. A user with `discordId = "abc123"` gets an item at PK/SK = `EXTID#discord#abc123` that stores the `userId`. Two reads: one to resolve the identity, one to fetch the user.
+- One mapping item is created per external identity (discord, username, etc.).
+- GSI1PK = `USERS` puts all users in one GSI partition so `Query` returns them all.
 
 ---
 
@@ -51,24 +67,22 @@
 
 ### DB Schema
 
-#### Team Item
+**Team Item**
 
-| PK              | SK         | GSI1PK  | GSI1SK          | Attributes          |
-| --------------- | ---------- | ------- | --------------- | ------------------- |
-| `TEAM#<teamId>` | `METADATA` | `TEAMS` | `TEAM#<teamId>` | `teamName`, …       |
+| PK              | SK         | GSI1PK  | GSI1SK          | Attributes    |
+| --------------- | ---------- | ------- | --------------- | ------------- |
+| `TEAM#<teamId>` | `METADATA` | `TEAMS` | `TEAM#<teamId>` | `teamName`, … |
 
 ### How Each Access Pattern Is Served
 
-| # | Pattern          | Operation                                                  |
-|---|------------------|------------------------------------------------------------|
-| 1 | Get team by teamId | `GetItem` — PK = `TEAM#<teamId>`, SK = `METADATA`       |
-| 2 | Get all teams      | `Query GSI1` — GSI1PK = `TEAMS`                         |
+| # | Pattern            | Operation                                          |
+|---|--------------------|----------------------------------------------------|
+| 1 | Get team by teamId | `GetItem` — PK = `TEAM#<teamId>`, SK = `METADATA` |
+| 2 | Get all teams      | `Query GSI1` — GSI1PK = `TEAMS`                   |
 
 ### Explanation
 
-- **`TEAM#<teamId>`** — The `TEAM#` prefix namespaces team items in the single table, same convention as User.
-- **`METADATA`** — Same constant SK convention, indicating the team's core record.
-- **`GSI1PK = TEAMS`** — Groups all team items under one GSI1 partition, allowing a single `Query` to fetch all teams. Same overloaded GSI1 pattern used by User.
+- Same pattern as User. GSI1PK = `TEAMS` groups all teams for a collection query.
 
 ---
 
@@ -84,28 +98,27 @@
 
 ### DB Schema
 
-#### Meal Participation Item
+**Meal Participation Item**
 
-| PK            | SK                          | GSI1PK          | GSI1SK                      | Attributes              |
-| ------------- | --------------------------- | --------------- | --------------------------- | ----------------------- |
-| `MEAL#<date>` | `USER#<userId>#<mealType>` | `USER#<userId>` | `MEAL#<date>#<mealType>`    | `status`, `updatedAt`, … |
+| PK            | SK                         | GSI1PK          | GSI1SK                   | Attributes               |
+| ------------- | -------------------------- | --------------- | ------------------------ | ------------------------ |
+| `MEAL#<date>` | `USER#<userId>#<mealType>` | `USER#<userId>` | `MEAL#<date>#<mealType>` | `status`, `updatedAt`, … |
 
 ### How Each Access Pattern Is Served
 
-| # | Pattern                                | Operation                                                                                  |
-|---|----------------------------------------|--------------------------------------------------------------------------------------------|
-| 1 | All participation records for a date   | `Query` — PK = `MEAL#<date>`                                                              |
-| 2 | A specific user's meals for a date     | `Query` — PK = `MEAL#<date>`, SK `begins_with` `USER#<userId>`                            |
-| 3 | A specific meal record                 | `GetItem` — PK = `MEAL#<date>`, SK = `USER#<userId>#<mealType>`                           |
-| 4 | A user's participation history         | `Query GSI1` — GSI1PK = `USER#<userId>`, GSI1SK `begins_with` `MEAL#`                     |
-| 5 | Upsert participation record            | `PutItem` — PK = `MEAL#<date>`, SK = `USER#<userId>#<mealType>`                           |
+| # | Pattern                              | Operation                                                              |
+|---|--------------------------------------|------------------------------------------------------------------------|
+| 1 | All participation records for a date | `Query` — PK = `MEAL#<date>`                                          |
+| 2 | User's meals for a date              | `Query` — PK = `MEAL#<date>`, SK `begins_with` `USER#<userId>`        |
+| 3 | Specific meal record                 | `GetItem` — PK = `MEAL#<date>`, SK = `USER#<userId>#<mealType>`       |
+| 4 | User's participation history         | `Query GSI1` — GSI1PK = `USER#<userId>`, GSI1SK `begins_with` `MEAL#` |
+| 5 | Upsert participation record          | `PutItem` — PK = `MEAL#<date>`, SK = `USER#<userId>#<mealType>`       |
 
 ### Explanation
 
-- **`MEAL#<date>`** — Partitions meal records by date. This makes date-based headcount queries (pattern #1) a single partition `Query`.
-- **`USER#<userId>#<mealType>`** — A composite SK that encodes both user and meal type. Using `begins_with USER#<userId>` retrieves all meal types for a user on that date (pattern #2). The full SK gives an exact record (pattern #3).
-- **`GSI1PK = USER#<userId>`** — The overloaded GSI1 is reused here to provide a user-centric view. Querying GSI1 with `begins_with MEAL#` returns all meal records for a user across all dates (pattern #4, for reporting).
-- **`GSI1SK = MEAL#<date>#<mealType>`** — Date comes first in the GSI1 sort key so history results are sorted chronologically.
+- PK partitions by date, so fetching all records for a date is a single partition query.
+- SK is a composite of userId and mealType. `begins_with USER#<userId>` gets all meal types for that user on a given date; the full SK targets one specific record.
+- GSI1 flips the access — PK becomes the user, SK becomes `MEAL#<date>#<mealType>`. This lets us pull a user's full history sorted by date.
 
 ---
 
@@ -120,27 +133,25 @@
 
 ### DB Schema
 
-#### Work Location Item
+**Work Location Item**
 
-| PK           | SK              | GSI1PK          | GSI1SK         | Attributes                   |
-| ------------ | --------------- | --------------- | -------------- | ---------------------------- |
-| `LOC#<date>` | `USER#<userId>` | `USER#<userId>` | `LOC#<date>`   | `location`, `updatedAt`, …   |
+| PK           | SK              | GSI1PK          | GSI1SK       | Attributes                 |
+| ------------ | --------------- | --------------- | ------------ | -------------------------- |
+| `LOC#<date>` | `USER#<userId>` | `USER#<userId>` | `LOC#<date>` | `location`, `updatedAt`, … |
 
 ### How Each Access Pattern Is Served
 
-| # | Pattern                              | Operation                                                                        |
-|---|--------------------------------------|----------------------------------------------------------------------------------|
-| 1 | All location records for a date      | `Query` — PK = `LOC#<date>`                                                     |
-| 2 | A specific user's location for a date | `GetItem` — PK = `LOC#<date>`, SK = `USER#<userId>`                            |
-| 3 | A user's location records for a month | `Query GSI1` — GSI1PK = `USER#<userId>`, GSI1SK `begins_with` `LOC#<YYYY-MM>`  |
-| 4 | Upsert location record               | `PutItem` — PK = `LOC#<date>`, SK = `USER#<userId>`                             |
+| # | Pattern                         | Operation                                                                      |
+|---|---------------------------------|--------------------------------------------------------------------------------|
+| 1 | All location records for a date | `Query` — PK = `LOC#<date>`                                                   |
+| 2 | User's location for a date      | `GetItem` — PK = `LOC#<date>`, SK = `USER#<userId>`                           |
+| 3 | User's locations for a month    | `Query GSI1` — GSI1PK = `USER#<userId>`, GSI1SK `begins_with` `LOC#<YYYY-MM>` |
+| 4 | Upsert location record          | `PutItem` — PK = `LOC#<date>`, SK = `USER#<userId>`                           |
 
 ### Explanation
 
-- **`LOC#<date>`** — Partitions location records by date, same approach as Meal Participation. All users' locations for one date live in one partition.
-- **`USER#<userId>`** — SK identifies the user. One location record per user per date.
-- **`GSI1PK = USER#<userId>`** — Reuses the overloaded GSI1 to provide a user-centric view. Querying with `begins_with LOC#<YYYY-MM>` returns all location records for a user in a given month (pattern #3, for WFH overage reporting).
-- **`GSI1SK = LOC#<date>`** — Date-based sort key in GSI1, enabling month-range queries and chronological ordering.
+- Same date-partitioned approach as Meal Participation. One record per user per date.
+- GSI1 flips access to user-centric. `begins_with LOC#<YYYY-MM>` pulls all location records for a user within a month.
 
 ---
 
@@ -153,24 +164,23 @@
 
 ### DB Schema
 
-#### Special Day Item
+**Special Day Item**
 
-| PK          | SK     | Attributes                       |
-| ----------- | ------ | -------------------------------- |
+| PK           | SK       | Attributes                        |
+| ------------ | -------- | --------------------------------- |
 | `SPECIALDAY` | `<date>` | `title`, `description`, `type`, … |
 
 ### How Each Access Pattern Is Served
 
-| # | Pattern                            | Operation                                                                                 |
-|---|------------------------------------|-------------------------------------------------------------------------------------------|
-| 1 | Get special day for a specific date | `GetItem` — PK = `SPECIALDAY`, SK = `<date>`                                            |
-| 2 | Get all special days in a month    | `Query` — PK = `SPECIALDAY`, SK `between` `<YYYY-MM-01>` and `<YYYY-MM-31>`              |
+| # | Pattern                             | Operation                                                                |
+|---|-------------------------------------|--------------------------------------------------------------------------|
+| 1 | Get special day for a specific date | `GetItem` — PK = `SPECIALDAY`, SK = `<date>`                            |
+| 2 | Get all special days in a month     | `Query` — PK = `SPECIALDAY`, SK `between` `YYYY-MM-01` and `YYYY-MM-31` |
 
 ### Explanation
 
-- **`SPECIALDAY`** — A fixed partition key that groups all special day items into one partition. This is safe because the total number of special days is small (low cardinality).
-- **`<date>`** — The raw date (e.g., `2026-03-15`) is used directly as the SK. Since all special days share the same PK, a `between` condition on SK efficiently retrieves all days within a month or any date range.
-- **No GSI needed** — Both access patterns are served directly from the main table.
+- Fixed PK groups all special days in one partition. Works fine given the low item count.
+- Raw date as SK allows range queries. No GSI needed.
 
 ---
 
@@ -184,23 +194,64 @@
 
 ### DB Schema
 
-#### Headcount Summary Item
+**Headcount Summary Item**
 
-| PK               | SK        | Attributes                                              |
-| ---------------- | --------- | ------------------------------------------------------- |
+| PK               | SK        | Attributes                                                |
+| ---------------- | --------- | --------------------------------------------------------- |
 | `SUMMARY#<date>` | `SUMMARY` | `totalOptIn`, `totalOptOut`, `totalWFH`, `generatedAt`, … |
 
 ### How Each Access Pattern Is Served
 
-| # | Pattern                             | Operation                                                         |
-|---|-------------------------------------|-------------------------------------------------------------------|
-| 1 | Generate headcount summary for a date | Application logic — reads from Meal, Location, Special Day, User |
-| 2 | Get a previously generated summary  | `GetItem` — PK = `SUMMARY#<date>`, SK = `SUMMARY`                |
-| 3 | Store a generated summary           | `PutItem` — PK = `SUMMARY#<date>`, SK = `SUMMARY`                |
+| # | Pattern                               | Operation                                                        |
+|---|---------------------------------------|------------------------------------------------------------------|
+| 1 | Generate headcount summary for a date | Application logic — reads Meal, Location, Special Day, User data |
+| 2 | Get a previously generated summary    | `GetItem` — PK = `SUMMARY#<date>`, SK = `SUMMARY`               |
+| 3 | Store a generated summary             | `PutItem` — PK = `SUMMARY#<date>`, SK = `SUMMARY`               |
 
 ### Explanation
 
-- **`SUMMARY#<date>`** — Each date gets its own partition for the summary record.
-- **`SUMMARY`** — A constant SK since there is only one summary per date.
-- **Pattern #1 is not a DB read** — It is application logic that queries Meal Participation, Work Location, Special Day, and User items, then computes and stores the result via pattern #3.
-- **No GSI needed** — Both read and write patterns are direct `GetItem`/`PutItem` operations.
+- One summary per date. Pattern #1 is computed in application code by reading other entities, then stored via pattern #3.
+- No GSI needed.
+
+---
+
+## GSI1 Usage
+
+GSI1 is overloaded — different entities project different values onto GSI1PK/GSI1SK.
+
+| Entity             | GSI1PK          | GSI1SK                   | Serves                              |
+| ------------------ | --------------- | ------------------------ | ----------------------------------- |
+| User               | `USERS`         | `USER#<userId>`          | Get all users                       |
+| Team               | `TEAMS`         | `TEAM#<teamId>`          | Get all teams                       |
+| Meal Participation | `USER#<userId>` | `MEAL#<date>#<mealType>` | User's meal history across dates    |
+| Work Location      | `USER#<userId>` | `LOC#<date>`             | User's location records for a month |
+
+Special Day and Headcount Summary don't use GSI1.
+
+Total GSIs: **1**
+
+---
+
+## Single Table Benefits
+
+- All entities in one table — single provisioning and billing unit.
+- GSI1 is overloaded to serve collection queries (all users, all teams) and user-centric queries (meal history, location history) without needing multiple indexes.
+- Prefixed keys keep entities separated and the table easy to scan/debug.
+- No cross-table coordination needed for transactions or batch operations.
+
+---
+
+## Summary
+
+| Entity             | PK                     | SK                         | Uses GSI1 | Operations              |
+| ------------------ | ---------------------- | -------------------------- | --------- | ----------------------- |
+| User               | `USER#<userId>`        | `METADATA`                 | Yes       | GetItem                 |
+| Identity Mapping   | `EXTID#<type>#<value>` | `EXTID#<type>#<value>`     | No        | GetItem                 |
+| Team               | `TEAM#<teamId>`        | `METADATA`                 | Yes       | GetItem                 |
+| Meal Participation | `MEAL#<date>`          | `USER#<userId>#<mealType>` | Yes       | Query, GetItem, PutItem |
+| Work Location      | `LOC#<date>`           | `USER#<userId>`            | Yes       | Query, GetItem, PutItem |
+| Special Day        | `SPECIALDAY`           | `<date>`                   | No        | GetItem, Query          |
+| Headcount Summary  | `SUMMARY#<date>`       | `SUMMARY`                  | No        | GetItem, PutItem        |
+
+- 7 item types, 1 table, 1 GSI
+- All 18 access patterns served without Scans

--- a/DynamoDB-Task/schema.md
+++ b/DynamoDB-Task/schema.md
@@ -141,3 +141,33 @@
 - **`USER#<userId>`** — SK identifies the user. One location record per user per date.
 - **`GSI1PK = USER#<userId>`** — Reuses the overloaded GSI1 to provide a user-centric view. Querying with `begins_with LOC#<YYYY-MM>` returns all location records for a user in a given month (pattern #3, for WFH overage reporting).
 - **`GSI1SK = LOC#<date>`** — Date-based sort key in GSI1, enabling month-range queries and chronological ordering.
+
+---
+
+## Special Day
+
+### Access Patterns
+
+1. Get special day for a specific date
+2. Get all special days in a month (or range)
+
+### DB Schema
+
+#### Special Day Item
+
+| PK          | SK     | Attributes                       |
+| ----------- | ------ | -------------------------------- |
+| `SPECIALDAY` | `<date>` | `title`, `description`, `type`, … |
+
+### How Each Access Pattern Is Served
+
+| # | Pattern                            | Operation                                                                                 |
+|---|------------------------------------|-------------------------------------------------------------------------------------------|
+| 1 | Get special day for a specific date | `GetItem` — PK = `SPECIALDAY`, SK = `<date>`                                            |
+| 2 | Get all special days in a month    | `Query` — PK = `SPECIALDAY`, SK `between` `<YYYY-MM-01>` and `<YYYY-MM-31>`              |
+
+### Explanation
+
+- **`SPECIALDAY`** — A fixed partition key that groups all special day items into one partition. This is safe because the total number of special days is small (low cardinality).
+- **`<date>`** — The raw date (e.g., `2026-03-15`) is used directly as the SK. Since all special days share the same PK, a `between` condition on SK efficiently retrieves all days within a month or any date range.
+- **No GSI needed** — Both access patterns are served directly from the main table.

--- a/DynamoDB-Task/schema.md
+++ b/DynamoDB-Task/schema.md
@@ -1,0 +1,41 @@
+# DynamoDB Single-Table Schema
+
+## Table Name: `MHP_Table`
+
+## User
+
+### Access Patterns
+
+1. Get user by userId
+2. Get user by external identity (e.g., discordId, username)
+3. Get all users
+
+### DB Schema
+
+#### User Item
+
+| PK              | SK         | GSI1PK  | GSI1SK          | Attributes                                           |
+| --------------- | ---------- | ------- | --------------- | ---------------------------------------------------- |
+| `USER#<userId>` | `METADATA` | `USERS` | `USER#<userId>` | `name`, `discordId`, `username`, `teamId`, `role`, … |
+
+#### Identity Mapping Item
+
+| PK                     | SK                     | Attributes |
+| ---------------------- | ---------------------- | ---------- |
+| `EXTID#<type>#<value>` | `EXTID#<type>#<value>` | `userId`   |
+
+### How Each Access Pattern Is Served
+
+| # | Pattern                       | Operation                                                                                                      |
+|---|-------------------------------|----------------------------------------------------------------------------------------------------------------|
+| 1 | Get user by userId            | `GetItem` — PK = `USER#<userId>`, SK = `METADATA`                                                             |
+| 2 | Get user by external identity | `GetItem` — PK = `EXTID#<type>#<value>`, SK = `EXTID#<type>#<value>` → returns `userId`, then fetch User item  |
+| 3 | Get all users                 | `Query GSI1` — GSI1PK = `USERS`                                                                               |
+
+### Explanation
+
+- **`USER#<userId>`** — The `USER#` prefix namespaces user items so they don't collide with other entity types in the single table.
+- **`METADATA`** — A constant sort key indicating this is the entity's core record (as opposed to related child items).
+- **Identity Mapping Items** — Separate items for reverse lookups. For example, a user with `discordId = "abc123"` gets an extra item with PK/SK = `EXTID#discord#abc123`. This avoids needing a GSI for identity lookups — a simple two-step read (`GetItem` for the mapping → `GetItem` for the user) handles it.
+  - When a user is created, one identity-mapping item is written per external identity (e.g., one for `discord`, one for `username`).
+- **`GSI1PK = USERS`** — All user items share the same GSI1 partition key `USERS`, which allows a single `Query` on GSI1 to return every user. `GSI1SK = USER#<userId>` provides sort order and uniqueness within that partition.

--- a/DynamoDB-Task/schema.md
+++ b/DynamoDB-Task/schema.md
@@ -171,3 +171,36 @@
 - **`SPECIALDAY`** — A fixed partition key that groups all special day items into one partition. This is safe because the total number of special days is small (low cardinality).
 - **`<date>`** — The raw date (e.g., `2026-03-15`) is used directly as the SK. Since all special days share the same PK, a `between` condition on SK efficiently retrieves all days within a month or any date range.
 - **No GSI needed** — Both access patterns are served directly from the main table.
+
+---
+
+## Headcount Summary
+
+### Access Patterns
+
+1. Generate headcount summary for a date (reads from Participation, Work Location, Special Day, User)
+2. Get a previously generated summary for a date
+3. Store a generated summary
+
+### DB Schema
+
+#### Headcount Summary Item
+
+| PK               | SK        | Attributes                                              |
+| ---------------- | --------- | ------------------------------------------------------- |
+| `SUMMARY#<date>` | `SUMMARY` | `totalOptIn`, `totalOptOut`, `totalWFH`, `generatedAt`, … |
+
+### How Each Access Pattern Is Served
+
+| # | Pattern                             | Operation                                                         |
+|---|-------------------------------------|-------------------------------------------------------------------|
+| 1 | Generate headcount summary for a date | Application logic — reads from Meal, Location, Special Day, User |
+| 2 | Get a previously generated summary  | `GetItem` — PK = `SUMMARY#<date>`, SK = `SUMMARY`                |
+| 3 | Store a generated summary           | `PutItem` — PK = `SUMMARY#<date>`, SK = `SUMMARY`                |
+
+### Explanation
+
+- **`SUMMARY#<date>`** — Each date gets its own partition for the summary record.
+- **`SUMMARY`** — A constant SK since there is only one summary per date.
+- **Pattern #1 is not a DB read** — It is application logic that queries Meal Participation, Work Location, Special Day, and User items, then computes and stores the result via pattern #3.
+- **No GSI needed** — Both read and write patterns are direct `GetItem`/`PutItem` operations.

--- a/DynamoDB-Task/schema.md
+++ b/DynamoDB-Task/schema.md
@@ -39,3 +39,33 @@
 - **Identity Mapping Items** — Separate items for reverse lookups. For example, a user with `discordId = "abc123"` gets an extra item with PK/SK = `EXTID#discord#abc123`. This avoids needing a GSI for identity lookups — a simple two-step read (`GetItem` for the mapping → `GetItem` for the user) handles it.
   - When a user is created, one identity-mapping item is written per external identity (e.g., one for `discord`, one for `username`).
 - **`GSI1PK = USERS`** — All user items share the same GSI1 partition key `USERS`, which allows a single `Query` on GSI1 to return every user. `GSI1SK = USER#<userId>` provides sort order and uniqueness within that partition.
+
+---
+
+## Team
+
+### Access Patterns
+
+1. Get team by teamId
+2. Get all teams
+
+### DB Schema
+
+#### Team Item
+
+| PK              | SK         | GSI1PK  | GSI1SK          | Attributes          |
+| --------------- | ---------- | ------- | --------------- | ------------------- |
+| `TEAM#<teamId>` | `METADATA` | `TEAMS` | `TEAM#<teamId>` | `teamName`, …       |
+
+### How Each Access Pattern Is Served
+
+| # | Pattern          | Operation                                                  |
+|---|------------------|------------------------------------------------------------|
+| 1 | Get team by teamId | `GetItem` — PK = `TEAM#<teamId>`, SK = `METADATA`       |
+| 2 | Get all teams      | `Query GSI1` — GSI1PK = `TEAMS`                         |
+
+### Explanation
+
+- **`TEAM#<teamId>`** — The `TEAM#` prefix namespaces team items in the single table, same convention as User.
+- **`METADATA`** — Same constant SK convention, indicating the team's core record.
+- **`GSI1PK = TEAMS`** — Groups all team items under one GSI1 partition, allowing a single `Query` to fetch all teams. Same overloaded GSI1 pattern used by User.

--- a/DynamoDB-Task/schema.md
+++ b/DynamoDB-Task/schema.md
@@ -69,3 +69,40 @@
 - **`TEAM#<teamId>`** — The `TEAM#` prefix namespaces team items in the single table, same convention as User.
 - **`METADATA`** — Same constant SK convention, indicating the team's core record.
 - **`GSI1PK = TEAMS`** — Groups all team items under one GSI1 partition, allowing a single `Query` to fetch all teams. Same overloaded GSI1 pattern used by User.
+
+---
+
+## Meal Participation
+
+### Access Patterns
+
+1. Get all participation records for a date (headcount — all users, one date)
+2. Get a specific user's meals for a date (users can view/opt out here)
+3. Get a specific meal record (user + date + mealType)
+4. Get a user's participation history across dates (reporting)
+5. Upsert participation record
+
+### DB Schema
+
+#### Meal Participation Item
+
+| PK            | SK                          | GSI1PK          | GSI1SK                      | Attributes              |
+| ------------- | --------------------------- | --------------- | --------------------------- | ----------------------- |
+| `MEAL#<date>` | `USER#<userId>#<mealType>` | `USER#<userId>` | `MEAL#<date>#<mealType>`    | `status`, `updatedAt`, … |
+
+### How Each Access Pattern Is Served
+
+| # | Pattern                                | Operation                                                                                  |
+|---|----------------------------------------|--------------------------------------------------------------------------------------------|
+| 1 | All participation records for a date   | `Query` — PK = `MEAL#<date>`                                                              |
+| 2 | A specific user's meals for a date     | `Query` — PK = `MEAL#<date>`, SK `begins_with` `USER#<userId>`                            |
+| 3 | A specific meal record                 | `GetItem` — PK = `MEAL#<date>`, SK = `USER#<userId>#<mealType>`                           |
+| 4 | A user's participation history         | `Query GSI1` — GSI1PK = `USER#<userId>`, GSI1SK `begins_with` `MEAL#`                     |
+| 5 | Upsert participation record            | `PutItem` — PK = `MEAL#<date>`, SK = `USER#<userId>#<mealType>`                           |
+
+### Explanation
+
+- **`MEAL#<date>`** — Partitions meal records by date. This makes date-based headcount queries (pattern #1) a single partition `Query`.
+- **`USER#<userId>#<mealType>`** — A composite SK that encodes both user and meal type. Using `begins_with USER#<userId>` retrieves all meal types for a user on that date (pattern #2). The full SK gives an exact record (pattern #3).
+- **`GSI1PK = USER#<userId>`** — The overloaded GSI1 is reused here to provide a user-centric view. Querying GSI1 with `begins_with MEAL#` returns all meal records for a user across all dates (pattern #4, for reporting).
+- **`GSI1SK = MEAL#<date>#<mealType>`** — Date comes first in the GSI1 sort key so history results are sorted chronologically.

--- a/DynamoDB-Task/schema.md
+++ b/DynamoDB-Task/schema.md
@@ -106,3 +106,38 @@
 - **`USER#<userId>#<mealType>`** — A composite SK that encodes both user and meal type. Using `begins_with USER#<userId>` retrieves all meal types for a user on that date (pattern #2). The full SK gives an exact record (pattern #3).
 - **`GSI1PK = USER#<userId>`** — The overloaded GSI1 is reused here to provide a user-centric view. Querying GSI1 with `begins_with MEAL#` returns all meal records for a user across all dates (pattern #4, for reporting).
 - **`GSI1SK = MEAL#<date>#<mealType>`** — Date comes first in the GSI1 sort key so history results are sorted chronologically.
+
+---
+
+## Work Location
+
+### Access Patterns
+
+1. Get all location records for a date (headcount — all users, one date)
+2. Get a specific user's location for a date
+3. Get a user's location records for a month (WFH overage report)
+4. Upsert location record
+
+### DB Schema
+
+#### Work Location Item
+
+| PK           | SK              | GSI1PK          | GSI1SK         | Attributes                   |
+| ------------ | --------------- | --------------- | -------------- | ---------------------------- |
+| `LOC#<date>` | `USER#<userId>` | `USER#<userId>` | `LOC#<date>`   | `location`, `updatedAt`, …   |
+
+### How Each Access Pattern Is Served
+
+| # | Pattern                              | Operation                                                                        |
+|---|--------------------------------------|----------------------------------------------------------------------------------|
+| 1 | All location records for a date      | `Query` — PK = `LOC#<date>`                                                     |
+| 2 | A specific user's location for a date | `GetItem` — PK = `LOC#<date>`, SK = `USER#<userId>`                            |
+| 3 | A user's location records for a month | `Query GSI1` — GSI1PK = `USER#<userId>`, GSI1SK `begins_with` `LOC#<YYYY-MM>`  |
+| 4 | Upsert location record               | `PutItem` — PK = `LOC#<date>`, SK = `USER#<userId>`                             |
+
+### Explanation
+
+- **`LOC#<date>`** — Partitions location records by date, same approach as Meal Participation. All users' locations for one date live in one partition.
+- **`USER#<userId>`** — SK identifies the user. One location record per user per date.
+- **`GSI1PK = USER#<userId>`** — Reuses the overloaded GSI1 to provide a user-centric view. Querying with `begins_with LOC#<YYYY-MM>` returns all location records for a user in a given month (pattern #3, for WFH overage reporting).
+- **`GSI1SK = LOC#<date>`** — Date-based sort key in GSI1, enabling month-range queries and chronological ordering.


### PR DESCRIPTION
<!-- Link to the issue this PR addresses -->
Closes #59 

## Dependencies

None - standalone documentation PR.

## What does this PR do?

Documents the DynamoDB single-table schema design for the MHP system. The design uses a single table (`MHP_Table`) with one overloaded GSI to support all 18 access patterns across User, Team, Meal Participation, Work Location, Special Day, and Headcount Summary entities.

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor
- [x] Documentation

## What was changed

### Overview

Designed a single-table DynamoDB schema that puts all 7 item types into one table (`MHP_Table`) with 1 overloaded GSI. No Scans required for any access pattern.

### Key Design Decisions

1. **Single-Table Architecture**: All entities stored in one table — User, Identity Mapping, Team, Meal Participation, Work Location, Special Day, Headcount Summary.

2. **Overloaded GSI1**: One GSI serves four different access patterns by projecting different values per entity type:
   - `USERS` / `USER#<userId>` — get all users
   - `TEAMS` / `TEAM#<teamId>` — get all teams
   - `USER#<userId>` / `MEAL#<date>#<mealType>` — user's meal history across dates
   - `USER#<userId>` / `LOC#<date>` — user's location records for a month

3. **Identity Mapping Items**: Reverse lookups by external identity (discordId, username) handled via separate `EXTID#<type>#<value>` items instead of a second GSI. Two reads: resolve identity → fetch user.

4. **Date-Partitioned Entities**: Meal Participation and Work Location use date as PK (`MEAL#<date>`, `LOC#<date>`) for efficient headcount queries. GSI1 flips the access to user-centric for history/reporting queries.

5. **Fixed-PK Entities**: Special Day uses a fixed PK (`SPECIALDAY`) with date as SK for range queries. Headcount Summary uses `SUMMARY#<date>` with constant SK. Neither needs GSI1.

### Schema Structure

| Entity             | PK                     | SK                         | Uses GSI1 | Operations              |
| ------------------ | ---------------------- | -------------------------- | --------- | ----------------------- |
| User               | `USER#<userId>`        | `METADATA`                 | Yes       | GetItem                 |
| Identity Mapping   | `EXTID#<type>#<value>` | `EXTID#<type>#<value>`     | No        | GetItem                 |
| Team               | `TEAM#<teamId>`        | `METADATA`                 | Yes       | GetItem                 |
| Meal Participation | `MEAL#<date>`          | `USER#<userId>#<mealType>` | Yes       | Query, GetItem, PutItem |
| Work Location      | `LOC#<date>`           | `USER#<userId>`            | Yes       | Query, GetItem, PutItem |
| Special Day        | `SPECIALDAY`           | `<date>`                   | No        | GetItem, Query          |
| Headcount Summary  | `SUMMARY#<date>`       | `SUMMARY`                  | No        | GetItem, PutItem        |

## Changelog

- Added access patterns documentation ([`access_patterns.md`](access_patterns.md))
- Added single-table DynamoDB schema design ([`schema.md`](schema.md))
- 7 item types, 1 table, 1 overloaded GSI, 18 access patterns, no Scans

## How to Test

Documentation-only PR. Review [`schema.md`](schema.md) against [`access_patterns.md`](access_patterns.md) to verify:

1. All 18 access patterns have a corresponding key design and DynamoDB operation
2. PK/SK patterns support the required query conditions (`GetItem`, `Query`, `begins_with`, `between`)
3. GSI1 overloading correctly maps each entity's GSI1PK/GSI1SK

## Rollback Plan

No rollback needed — documentation only. Update the files if the schema design needs revision.

## Checklist

- [x] All 18 access patterns are covered
- [x] Schema uses 1 GSI (within the max 2 budget)
- [x] Key conventions are documented
- [x] No Scans required for any access pattern
- [x] Documentation is clear for developers implementing the data access layer
