### PR TITLE
[PR-6] feat: Discord bot — Lambda handler, services & slash command registration

### DIFF
--- a/Task-2/.env.example
+++ b/Task-2/.env.example
@@ -1,6 +1,7 @@
 # Discord Application
 DISCORD_PUBLIC_KEY=your_discord_application_public_key_here
 DISCORD_BOT_TOKEN=your_discord_bot_token_here
+DISCORD_APPLICATION_ID=your_discord_application_id_here
 
 # AWS
 DYNAMODB_MEAL_TABLE=mhp-meal-records

--- a/Task-2/.gitignore
+++ b/Task-2/.gitignore
@@ -18,3 +18,7 @@ htmlcov/
 # IDE
 .vscode/
 .idea/
+
+
+issues/
+pr/

--- a/Task-2/app/config.py
+++ b/Task-2/app/config.py
@@ -6,6 +6,7 @@ class Settings(BaseSettings):
     # Discord Application
     discord_public_key: str
     discord_bot_token: str
+    discord_application_id: str
 
     # AWS
     dynamodb_meal_table: str = "mhp-meal-records"

--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -111,17 +111,23 @@ def _handle_meal_update(interaction: DiscordInteraction, options: list) -> dict:
     if not target_date:
         return _reply("Please provide a date.")
     opt_in_val = _get_option(options, "opt_in")
-    location = _get_option(options, "location")
     meal_type = _get_option(options, "meal_type")
     msgs = []
     if opt_in_val is not None:
         fn = meal_service.opt_in if opt_in_val else meal_service.opt_out
         msgs.append(fn(target_date, user_id, updated_by=user_id))
-    if location:
-        msgs.append(meal_service.update_location(target_date, user_id, location, updated_by=user_id))
     if meal_type:
         msgs.append(meal_service.update_meal_type(target_date, user_id, meal_type, updated_by=user_id))
     return _reply("\n".join(msgs) if msgs else "Nothing to update.")
+
+
+def _handle_meal_location(interaction: DiscordInteraction, options: list) -> dict:
+    user_id = interaction.get_user().id
+    target_date = _get_option(options, "date")
+    location = _get_option(options, "location")
+    if not target_date or not location:
+        return _reply("Please provide both date and location.")
+    return _reply(meal_service.update_location(target_date, user_id, location, updated_by=user_id))
 
 
 def _handle_meal_optout(interaction: DiscordInteraction, options: list) -> dict:
@@ -130,7 +136,7 @@ def _handle_meal_optout(interaction: DiscordInteraction, options: list) -> dict:
     if not target_date:
         return _reply("Please provide a date.")
     if not meal_service.is_event_day(target_date):
-        return _reply(f"{target_date} is not an event day. Use `/meal update` to change your meal preference.")
+        return _reply(f"{target_date} is not an event day. Use `/meal update` or `/meal location` to change your meal preference.")
     return _reply(meal_service.opt_out(target_date, user_id, updated_by=user_id))
 
 
@@ -204,6 +210,7 @@ def _handle_meal_event(interaction: DiscordInteraction, options: list) -> dict:
 _MEAL_HANDLERS = {
     "status": _handle_meal_status,
     "update": _handle_meal_update,
+    "location": _handle_meal_location,
     "optout": _handle_meal_optout,
     "summary": _handle_meal_summary,
     "summary-all": _handle_meal_summary_all,

--- a/Task-2/app/services/discord_service.py
+++ b/Task-2/app/services/discord_service.py
@@ -10,6 +10,7 @@ from app.config import settings
 logger = logging.getLogger(__name__)
 
 DISCORD_API_BASE = "https://discord.com/api/v10"
+_USER_AGENT = "DiscordBot (https://github.com/ghalib-craftsmen/cea-tasks, 1.0)"
 
 
 def send_followup(interaction_token: str, content: str, ephemeral: bool = True) -> None:
@@ -26,6 +27,7 @@ def send_followup(interaction_token: str, content: str, ephemeral: bool = True) 
         headers={
             "Content-Type": "application/json",
             "Authorization": f"Bot {settings.discord_bot_token}",
+            "User-Agent": _USER_AGENT,
         },
         method="POST",
     )
@@ -53,6 +55,7 @@ def send_channel_message(channel_id: str, content: str) -> None:
         headers={
             "Content-Type": "application/json",
             "Authorization": f"Bot {settings.discord_bot_token}",
+            "User-Agent": _USER_AGENT,
         },
         method="POST",
     )

--- a/Task-2/app/services/discord_service.py
+++ b/Task-2/app/services/discord_service.py
@@ -14,7 +14,7 @@ DISCORD_API_BASE = "https://discord.com/api/v10"
 
 def send_followup(interaction_token: str, content: str, ephemeral: bool = True) -> None:
     """Send a deferred follow-up message to Discord via the REST API."""
-    url = f"{DISCORD_API_BASE}/webhooks/{settings.discord_public_key}/{interaction_token}"
+    url = f"{DISCORD_API_BASE}/webhooks/{settings.discord_application_id}/{interaction_token}"
     payload = {"content": content}
     if ephemeral:
         payload["flags"] = 64  # EPHEMERAL flag

--- a/Task-2/register_commands.py
+++ b/Task-2/register_commands.py
@@ -101,7 +101,7 @@ COMMANDS = [
             {
                 "type": 1,
                 "name": "summary",
-                "description": "[Team Lead] View headcount summary for a date",
+                "description": "[Team Lead] View headcount and location split for a date",
                 "options": [
                     {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True}
                 ],
@@ -110,7 +110,7 @@ COMMANDS = [
             {
                 "type": 1,
                 "name": "summary-all",
-                "description": "[Admin] View org-wide headcount for a date",
+                "description": "[Admin] View org-wide headcount and location split for a date",
                 "options": [
                     {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True}
                 ],

--- a/Task-2/register_commands.py
+++ b/Task-2/register_commands.py
@@ -1,0 +1,198 @@
+"""
+Register all slash commands for the Meal Headcount Planner bot.
+
+Usage:
+    python register_commands.py
+
+Reads DISCORD_APPLICATION_ID, DISCORD_BOT_TOKEN, and AUTHORIZED_GUILD_ID
+from the environment (or .env file).
+
+Commands are registered guild-scoped (instant) rather than global (up to 1 hour delay).
+To switch to global, remove the GUILD_ID from the URL below.
+"""
+from __future__ import annotations
+
+import json
+import urllib.request
+import urllib.error
+
+from dotenv import load_dotenv
+
+load_dotenv()
+
+from app.config import settings  # noqa: E402 — load_dotenv must run first
+
+# Option types (Discord API)
+_STR = 3
+_BOOL = 5
+_USER = 6
+
+COMMANDS = [
+    {
+        "name": "meal",
+        "description": "Manage your meal preference",
+        "options": [
+            # /meal status [date]
+            {
+                "type": 1,
+                "name": "status",
+                "description": "Check your meal status for a date",
+                "options": [
+                    {
+                        "type": _STR,
+                        "name": "date",
+                        "description": "Target date (YYYY-MM-DD). Defaults to today.",
+                        "required": False,
+                    }
+                ],
+            },
+            # /meal update date [opt_in] [location] [meal_type]
+            {
+                "type": 1,
+                "name": "update",
+                "description": "Update your opt-in, location, or meal type",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True},
+                    {"type": _BOOL, "name": "opt_in", "description": "Opt in (true) or out (false)", "required": False},
+                    {
+                        "type": _STR,
+                        "name": "location",
+                        "description": "OFFICE or WFH",
+                        "required": False,
+                        "choices": [
+                            {"name": "Office", "value": "OFFICE"},
+                            {"name": "WFH", "value": "WFH"},
+                        ],
+                    },
+                    {
+                        "type": _STR,
+                        "name": "meal_type",
+                        "description": "Meal type",
+                        "required": False,
+                        "choices": [
+                            {"name": "Lunch", "value": "LUNCH"},
+                            {"name": "Snacks", "value": "SNACKS"},
+                            {"name": "Iftar", "value": "IFTAR"},
+                            {"name": "Event Dinner", "value": "EVENT_DINNER"},
+                            {"name": "Optional Dinner", "value": "OPTIONAL_DINNER"},
+                        ],
+                    },
+                ],
+            },
+            # /meal optout date
+            {
+                "type": 1,
+                "name": "optout",
+                "description": "Opt out of an event meal day",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Event date (YYYY-MM-DD)", "required": True}
+                ],
+            },
+            # /meal summary date  (Team Lead)
+            {
+                "type": 1,
+                "name": "summary",
+                "description": "[Team Lead] View headcount summary for a date",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True}
+                ],
+            },
+            # /meal summary-all date  (Admin)
+            {
+                "type": 1,
+                "name": "summary-all",
+                "description": "[Admin] View org-wide headcount for a date",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True}
+                ],
+            },
+            # /meal override user date [opt_in] [location]  (Admin)
+            {
+                "type": 1,
+                "name": "override",
+                "description": "[Admin] Override any user's meal record",
+                "options": [
+                    {"type": _USER, "name": "user", "description": "Target user", "required": True},
+                    {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True},
+                    {"type": _BOOL, "name": "opt_in", "description": "Opt in (true) or out (false)", "required": False},
+                    {
+                        "type": _STR,
+                        "name": "location",
+                        "description": "OFFICE or WFH",
+                        "required": False,
+                        "choices": [
+                            {"name": "Office", "value": "OFFICE"},
+                            {"name": "WFH", "value": "WFH"},
+                        ],
+                    },
+                ],
+            },
+            # /meal event date [action]  (Admin)
+            {
+                "type": 1,
+                "name": "event",
+                "description": "[Admin] Announce a configured event meal day",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Event date (YYYY-MM-DD)", "required": True},
+                    {
+                        "type": _STR,
+                        "name": "action",
+                        "description": "Action to perform (default: announce)",
+                        "required": False,
+                        "choices": [{"name": "Announce", "value": "announce"}],
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        "name": "special-day",
+        "description": "View configured special event days",
+        "options": [
+            # /special-day view date  (Admin)
+            {
+                "type": 1,
+                "name": "view",
+                "description": "[Admin] Check whether a date is a special event day",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Date to check (YYYY-MM-DD)", "required": True}
+                ],
+            }
+        ],
+    },
+]
+
+
+def register() -> None:
+    app_id = settings.discord_application_id
+    guild_id = settings.authorized_guild_id
+    token = settings.discord_bot_token
+
+    # Guild-scoped: instant propagation. For global (1hr delay), use:
+    # url = f"https://discord.com/api/v10/applications/{app_id}/commands"
+    url = f"https://discord.com/api/v10/applications/{app_id}/guilds/{guild_id}/commands"
+
+    data = json.dumps(COMMANDS).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bot {token}",
+        },
+        method="PUT",  # PUT replaces the full command list atomically
+    )
+
+    try:
+        with urllib.request.urlopen(req) as resp:
+            body = json.loads(resp.read())
+            print(f"OK — registered {len(body)} command(s):")
+            for cmd in body:
+                print(f"  /{cmd['name']}")
+    except urllib.error.HTTPError as e:
+        print(f"HTTP {e.code}: {e.read().decode()}")
+        raise
+
+
+if __name__ == "__main__":
+    register()

--- a/Task-2/register_commands.py
+++ b/Task-2/register_commands.py
@@ -46,24 +46,14 @@ COMMANDS = [
                     }
                 ],
             },
-            # /meal update date [opt_in] [location] [meal_type]
+            # /meal update date [opt_in] [meal_type]
             {
                 "type": 1,
                 "name": "update",
-                "description": "Update your opt-in, location, or meal type",
+                "description": "Update your opt-in status or meal type for a date",
                 "options": [
                     {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True},
                     {"type": _BOOL, "name": "opt_in", "description": "Opt in (true) or out (false)", "required": False},
-                    {
-                        "type": _STR,
-                        "name": "location",
-                        "description": "OFFICE or WFH",
-                        "required": False,
-                        "choices": [
-                            {"name": "Office", "value": "OFFICE"},
-                            {"name": "WFH", "value": "WFH"},
-                        ],
-                    },
                     {
                         "type": _STR,
                         "name": "meal_type",
@@ -75,6 +65,25 @@ COMMANDS = [
                             {"name": "Iftar", "value": "IFTAR"},
                             {"name": "Event Dinner", "value": "EVENT_DINNER"},
                             {"name": "Optional Dinner", "value": "OPTIONAL_DINNER"},
+                        ],
+                    },
+                ],
+            },
+            # /meal location date location
+            {
+                "type": 1,
+                "name": "location",
+                "description": "Set your work location for a date",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True},
+                    {
+                        "type": _STR,
+                        "name": "location",
+                        "description": "OFFICE or WFH",
+                        "required": True,
+                        "choices": [
+                            {"name": "Office", "value": "OFFICE"},
+                            {"name": "WFH", "value": "WFH"},
                         ],
                     },
                 ],

--- a/Task-2/register_commands.py
+++ b/Task-2/register_commands.py
@@ -179,6 +179,7 @@ def register() -> None:
         headers={
             "Content-Type": "application/json",
             "Authorization": f"Bot {token}",
+            "User-Agent": "DiscordBot (https://github.com/ghalib-craftsmen/cea-tasks/Task-2, 1.0)",
         },
         method="PUT",  # PUT replaces the full command list atomically
     )


### PR DESCRIPTION
<!-- Link to the issue this PR addresses -->
Closes #54 

## Dependencies

- _(none needed)_

## What does this PR do?

Implements the full Discord bot backend for the Meal Headcount Planner as an AWS Lambda function. Employees can update their meal opt-in status, work location, and meal type via slash commands. Team leads and admins get headcount summaries and override capabilities. Includes a standalone script to register all commands with the Discord API.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

## What was changed

### Project bootstrap
- `app/config.py` — `Settings(BaseSettings)` as the single source of truth for all env vars, including the new `DISCORD_APPLICATION_ID` field required for follow-up webhooks and command registration.
- `.env.example` — template covering all required variables.

### Pydantic models (`app/models/`)
- `discord_models.py` — typed models for Discord interaction payloads (`DiscordInteraction`, `Member`, `User`, `InteractionOption`).
- `meal_models.py` — `MealRecord` with DynamoDB `pk`/`sk` prefix serialisation and `to_user_history_dynamo()` for the write-through replica. `EventConfig` for `config/events.json`.

### Lambda handler (`app/handler.py`)
- Ed25519 signature verification (with 5-minute replay-attack window) runs before any business logic.
- Guild authorization guard rejects interactions from guilds other than `AUTHORIZED_GUILD_ID`.
- RBAC via `member.roles` from the verified payload — no external role store.
- Slash command dispatch via a dict (`_MEAL_HANDLERS`) rather than a chain of `if/elif` blocks.
- `/health` GET endpoint for monitoring.

### Service layer (`app/services/`)
- **`meal_service`** — cut-off enforcement (timezone-aware, DST-safe), `TransactWriteItems` atomic write-through to both DynamoDB tables, opt-in/out, location + meal type updates, WFH monthly soft-limit check (returns 0 on `ClientError` rather than re-raising).
- **`headcount_service`** — date-level summary with opt-in/out counts, office/WFH split, and event-day flag.
- **`discord_service`** — follow-up and channel message senders using `urllib` (no third-party HTTP client); explicit handling for `HTTPError`, `URLError`, and generic exceptions. URL uses `discord_application_id`, not `discord_public_key`.

### Command registration (`register_commands.py`)
- Standalone script using `PUT /applications/{app_id}/guilds/{guild_id}/commands` to atomically register all commands guild-scoped (instant propagation).
- Covers all 8 subcommands across `/meal` and `/special-day` with typed options and choices.

### Bug fixes included
- `send_followup` URL corrected to use `discord_application_id` instead of `discord_public_key`.
- `get_records_for_date` and `get_user_history` return safe defaults on `ClientError` instead of re-raising.
- `upsert_record` uses `TransactWriteItems` for atomic dual-table writes.
- Cut-off `cutoff_dt` computed as a naive datetime before timezone attachment to avoid DST drift.
- `/meal status` shows the default opted-in state when no DynamoDB record exists yet.
- Meal type input normalised to uppercase + underscore before validation.

## Changelog

```
Feature: Employees can update meal opt-in, work location, and meal type via Discord slash commands.
Feature: Team leads and admins can view headcount summaries per date via Discord.
Feature: Admins can override any user's record and broadcast event meal announcements.
Feature: WFH soft-limit warning appended to confirmation when a user reaches 5 WFH days in a month.
Feature: register_commands.py script for one-command guild-scoped slash command registration.
```

## How to Test

1. Copy `.env.example` to `.env` and fill in real Discord and AWS credentials.
2. Run `python register_commands.py` — confirm the output lists all 8 commands with no HTTP error.
3. In Discord, invoke each slash command and verify the ephemeral reply matches the expected behavior (see [issue-2.0.1](../issues/issue-2.0.1-discord-bot.md)).
4. Attempt an update for today's date — confirm rejection with the cut-off message.
5. Set work location to WFH five times in the same month — confirm the soft-limit warning appears on the fifth write.
6. Use `/meal event announce <date>` on a date in `config/events.json` — confirm a public (non-ephemeral) announcement is posted.
7. Use `/meal optout <date>` on a non-event date — confirm it is rejected with a helpful message.

## How QA Should Test

**Affected workflows:**
- Employee meal opt-in / opt-out for a future date.
- Employee work location and meal type update.
- Team Lead headcount summary view.
- Admin org-wide summary, record override, and event announcement.

**Specific checks:**
1. Verify Discord PING → PONG handshake passes (check Interaction endpoint status in Developer Portal).
2. Invoke `/meal status` with no date — confirm it defaults to today and shows the default opted-in status when no record exists.
3. Invoke `/meal update` with an invalid date (past or today) — confirm cut-off rejection message.
4. As a user without Team Lead role, invoke `/meal summary` — confirm permission-denied ephemeral reply.
5. As Admin, invoke `/meal override` for another user and verify the record is updated in DynamoDB.
6. Invoke `/meal event` on a date not in `config/events.json` — confirm "not configured as an event day" reply.
7. Invoke `/special-day view` on an event date — confirm description is returned; on a non-event date — confirm negative response.

## Rollback Plan

Revert this PR. No DynamoDB schema changes are required to roll back — the tables are provisioned separately and records written by this handler are backward-compatible.

## Checklist

- [x] My code follows the project style guidelines
- [ ] Code passes linting and type checks
- [ ] All tests pass
- [ ] I have added tests for my changes (if applicable)
- [ ] I have updated documentation (if applicable)

## Screenshots (if applicable)

N/A — Discord bot interactions; no UI changes.

## Note for Reviewer

- The `_verify_signature` function catches all exceptions from `VerifyKey.verify()` — worth confirming this is the right failure mode vs. letting unexpected errors propagate.
- `register_commands.py` uses `PUT` (full replace), so adding a new command and running the script is safe. Deleting a command from `COMMANDS` and re-running will remove it from Discord immediately.
- `config/events.json` is read on every invocation of `is_event_day()` / `_load_events()`. For Lambda this is fine given the bounded event list size, but worth flagging if the list grows significantly.
