### PR TITLE
[PR-8] feat: deploy CraftsMeal Discord bot to AWS two-Lambda serverless architecture (issue 2.10)

### DIFF
--- a/Task-2/.env.example
+++ b/Task-2/.env.example
@@ -6,7 +6,7 @@ DISCORD_APPLICATION_ID=your_discord_application_id_here
 # AWS
 DYNAMODB_TABLE=trainee-2026-abdullah-MHP_Table
 AWS_REGION=ap-southeast-1
-COMMAND_LAMBDA_NAME=trainee-2026-abdullah-mhp-command
+COMMAND_LAMBDA_NAME=trainee-2026-abdullah-craftsmeal-command
 
 # Discord Role IDs
 ROLE_TEAM_LEAD_ID=your_team_lead_role_id_here

--- a/Task-2/.env.example
+++ b/Task-2/.env.example
@@ -4,7 +4,7 @@ DISCORD_BOT_TOKEN=your_discord_bot_token_here
 DISCORD_APPLICATION_ID=your_discord_application_id_here
 
 # AWS
-DYNAMODB_TABLE=MHP_Table
+DYNAMODB_TABLE=trainee-2026-ghalib-MHP_Table
 AWS_REGION=ap-southeast-1
 COMMAND_LAMBDA_NAME=mhp-command
 

--- a/Task-2/.env.example
+++ b/Task-2/.env.example
@@ -4,7 +4,7 @@ DISCORD_BOT_TOKEN=your_discord_bot_token_here
 DISCORD_APPLICATION_ID=your_discord_application_id_here
 
 # AWS
-DYNAMODB_TABLE=trainee-2026-ghalib-MHP_Table
+DYNAMODB_TABLE=trainee-2026-abdullah-MHP_Table
 AWS_REGION=ap-southeast-1
 COMMAND_LAMBDA_NAME=mhp-command
 

--- a/Task-2/.env.example
+++ b/Task-2/.env.example
@@ -6,7 +6,7 @@ DISCORD_APPLICATION_ID=your_discord_application_id_here
 # AWS
 DYNAMODB_TABLE=trainee-2026-abdullah-MHP_Table
 AWS_REGION=ap-southeast-1
-COMMAND_LAMBDA_NAME=mhp-command
+COMMAND_LAMBDA_NAME=trainee-2026-abdullah-mhp-command
 
 # Discord Role IDs
 ROLE_TEAM_LEAD_ID=your_team_lead_role_id_here

--- a/Task-2/.env.example
+++ b/Task-2/.env.example
@@ -6,6 +6,7 @@ DISCORD_APPLICATION_ID=your_discord_application_id_here
 # AWS
 DYNAMODB_TABLE=MHP_Table
 AWS_REGION=ap-southeast-1
+COMMAND_LAMBDA_NAME=mhp-command
 
 # Discord Role IDs
 ROLE_TEAM_LEAD_ID=your_team_lead_role_id_here

--- a/Task-2/.env.example
+++ b/Task-2/.env.example
@@ -4,8 +4,7 @@ DISCORD_BOT_TOKEN=your_discord_bot_token_here
 DISCORD_APPLICATION_ID=your_discord_application_id_here
 
 # AWS
-DYNAMODB_MEAL_TABLE=mhp-meal-records
-DYNAMODB_USER_HISTORY_TABLE=mhp-user-history
+DYNAMODB_TABLE=MHP_Table
 AWS_REGION=ap-southeast-1
 
 # Discord Role IDs

--- a/Task-2/.gitignore
+++ b/Task-2/.gitignore
@@ -19,6 +19,6 @@ htmlcov/
 .vscode/
 .idea/
 
-
+# Github templates
 issues/
 pr/

--- a/Task-2/.gitignore
+++ b/Task-2/.gitignore
@@ -22,3 +22,7 @@ htmlcov/
 # Github templates
 issues/
 pr/
+
+# Lambda build artifacts
+package/
+lambda.zip

--- a/Task-2/app/config.py
+++ b/Task-2/app/config.py
@@ -24,8 +24,8 @@ class Settings(BaseSettings):
     timezone: str = "Asia/Dhaka"
     default_cutoff_time: str = "00:00"
 
-    # Internal API (dashboard)
-    internal_api_key: str
+    # Internal API (dashboard) — not used until dashboard is implemented
+    internal_api_key: str = ""
 
 
 settings = Settings()  

--- a/Task-2/app/config.py
+++ b/Task-2/app/config.py
@@ -11,7 +11,7 @@ class Settings(BaseSettings):
     # AWS
     dynamodb_table: str = "trainee-2026-abdullah-MHP_Table"
     aws_region: str = "ap-southeast-1"
-    command_lambda_name: str = "trainee-2026-abdullah-mhp-command"
+    command_lambda_name: str = "trainee-2026-abdullah-craftsmeal-command"
 
     # Discord Role IDs
     role_team_lead_id: str

--- a/Task-2/app/config.py
+++ b/Task-2/app/config.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
     discord_application_id: str
 
     # AWS
-    dynamodb_table: str = "MHP_Table"
+    dynamodb_table: str = "trainee-2026-ghalib-MHP_Table"
     aws_region: str = "ap-southeast-1"
     command_lambda_name: str = "mhp-command"
 

--- a/Task-2/app/config.py
+++ b/Task-2/app/config.py
@@ -9,7 +9,7 @@ class Settings(BaseSettings):
     discord_application_id: str
 
     # AWS
-    dynamodb_table: str = "trainee-2026-ghalib-MHP_Table"
+    dynamodb_table: str = "trainee-2026-abdullah-MHP_Table"
     aws_region: str = "ap-southeast-1"
     command_lambda_name: str = "mhp-command"
 

--- a/Task-2/app/config.py
+++ b/Task-2/app/config.py
@@ -9,8 +9,7 @@ class Settings(BaseSettings):
     discord_application_id: str
 
     # AWS
-    dynamodb_meal_table: str = "mhp-meal-records"
-    dynamodb_user_history_table: str = "mhp-user-history"
+    dynamodb_table: str = "MHP_Table"
     aws_region: str = "ap-southeast-1"
 
     # Discord Role IDs

--- a/Task-2/app/config.py
+++ b/Task-2/app/config.py
@@ -11,7 +11,7 @@ class Settings(BaseSettings):
     # AWS
     dynamodb_table: str = "trainee-2026-abdullah-MHP_Table"
     aws_region: str = "ap-southeast-1"
-    command_lambda_name: str = "mhp-command"
+    command_lambda_name: str = "trainee-2026-abdullah-mhp-command"
 
     # Discord Role IDs
     role_team_lead_id: str

--- a/Task-2/app/config.py
+++ b/Task-2/app/config.py
@@ -11,6 +11,7 @@ class Settings(BaseSettings):
     # AWS
     dynamodb_table: str = "MHP_Table"
     aws_region: str = "ap-southeast-1"
+    command_lambda_name: str = "mhp-command"
 
     # Discord Role IDs
     role_team_lead_id: str

--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -318,5 +318,10 @@ def handler(event: dict, context: Any) -> dict:
     if payload.get("type") != _APPLICATION_COMMAND:
         return _err(400, "Unsupported interaction type")
 
-    interaction = DiscordInteraction(**payload)
+    try:
+        interaction = DiscordInteraction(**payload)
+    except Exception as exc:
+        logger.error("Failed to parse interaction payload: %s", exc)
+        return _err(400, "Invalid interaction payload")
+
     return _route_command(interaction)

--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -119,7 +119,6 @@ def _handle_meal_override(interaction: DiscordInteraction, options: list) -> tup
     if not target_user or not target_date:
         return _reply("Please provide both user and date.")
     opt_in_val = _get_option(options, "opt_in")
-    location = _get_option(options, "location")
     meal_types = _collect_meal_types(options)
     msgs = []
     if opt_in_val is not None:
@@ -127,8 +126,6 @@ def _handle_meal_override(interaction: DiscordInteraction, options: list) -> tup
         msgs.append(fn(target_date, target_user, updated_by=user_id, meal_types=meal_types, bypass_cutoff=True))
     elif meal_types:
         msgs.append(meal_service.opt_out(target_date, target_user, updated_by=user_id, meal_types=meal_types, bypass_cutoff=True))
-    if location:
-        msgs.append(meal_service.update_location(target_date, target_user, location, updated_by=user_id, bypass_cutoff=True))
     return _reply("\n".join(msgs) if msgs else "Nothing to update.")
 
 

--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -179,12 +179,15 @@ def _handle_meal_override(interaction: DiscordInteraction, options: list) -> dic
         return _reply("Please provide both user and date.")
     opt_in_val = _get_option(options, "opt_in")
     location = _get_option(options, "location")
+    meal_type = _get_option(options, "meal_type")
     msgs = []
     if opt_in_val is not None:
         fn = meal_service.opt_in if opt_in_val else meal_service.opt_out
         msgs.append(fn(target_date, target_user, updated_by=user_id, bypass_cutoff=True))
     if location:
         msgs.append(meal_service.update_location(target_date, target_user, location, updated_by=user_id, bypass_cutoff=True))
+    if meal_type:
+        msgs.append(meal_service.update_meal_type(target_date, target_user, meal_type, updated_by=user_id, bypass_cutoff=True))
     return _reply("\n".join(msgs) if msgs else "Nothing to update.")
 
 

--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -60,14 +60,6 @@ def _handle_meal_update(interaction: DiscordInteraction, options: list) -> tuple
     return _reply("\n".join(msgs) if msgs else "Nothing to update.")
 
 
-def _handle_meal_location(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
-    user_id = interaction.get_user().id
-    target_date = _get_option(options, "date")
-    location = _get_option(options, "location")
-    if not target_date or not location:
-        return _reply("Please provide both date and location.")
-    return _reply(meal_service.update_location(target_date, user_id, location, updated_by=user_id))
-
 
 def _handle_meal_optout(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
     user_id = interaction.get_user().id
@@ -75,7 +67,7 @@ def _handle_meal_optout(interaction: DiscordInteraction, options: list) -> tuple
     if not target_date:
         return _reply("Please provide a date.")
     if not meal_service.is_event_day(target_date):
-        return _reply(f"{target_date} is not an event day. Use `/meal update` or `/meal location` to change your meal preference.")
+        return _reply(f"{target_date} is not an event day. Use `/meal update` or `/location` to change your meal preference.")
     return _reply(meal_service.opt_out(target_date, user_id, updated_by=user_id))
 
 
@@ -149,10 +141,18 @@ def _handle_meal_event(interaction: DiscordInteraction, options: list) -> tuple[
     return _reply("Unknown action.")
 
 
+def _handle_work_location(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
+    user_id = interaction.get_user().id
+    target_date = _get_option(options, "date")
+    location = _get_option(options, "location")
+    if not target_date or not location:
+        return _reply("Please provide both date and location.")
+    return _reply(meal_service.update_location(target_date, user_id, location, updated_by=user_id))
+
+
 _MEAL_HANDLERS = {
     "status":      _handle_meal_status,
     "update":      _handle_meal_update,
-    "location":    _handle_meal_location,
     "optout":      _handle_meal_optout,
     "summary":     _handle_meal_summary,
     "summary-all": _handle_meal_summary_all,
@@ -205,6 +205,9 @@ def _route_command(interaction: DiscordInteraction) -> tuple[str, bool]:
         if not subcommand:
             return _reply("Please specify a subcommand.")
         return _handle_special_day(interaction, subcommand, sub_options)
+
+    if command == "location":
+        return _handle_work_location(interaction, options)
 
     return _reply("Unknown command.")
 

--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import date as _date
 from typing import Any
 
 from app.config import settings
@@ -36,7 +37,6 @@ def _get_option(options: list, name: str) -> Any:
 
 
 def _handle_meal_status(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
-    from datetime import date as _date
     user_id = interaction.get_user().id
     target_date = _get_option(options, "date") or str(_date.today())
     record = meal_service.get_record(target_date, user_id) or MealRecord(date=target_date, user_id=user_id)

--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -40,8 +40,19 @@ def _handle_meal_status(interaction: DiscordInteraction, options: list) -> tuple
     user_id = interaction.get_user().id
     target_date = _get_option(options, "date") or str(_date.today())
     record = meal_service.get_record(target_date, user_id) or MealRecord(date=target_date, user_id=user_id)
-    status = "opted in" if record.meal_opt_in else "opted out"
-    return _reply(f"**{target_date}** — {status} | Location: {record.work_location} | Meal: {record.meal_type}")
+    if not record.meal_opt_in:
+        status = "opted out (all meals)"
+    elif record.opted_out_meals:
+        status = f"opted out of: {', '.join(record.opted_out_meals)}"
+    else:
+        status = "opted in (all meals)"
+    return _reply(f"**{target_date}** — {status} | Location: {record.work_location}")
+
+
+def _collect_meal_types(options: list) -> list[str] | None:
+    """Collect selected meal type booleans. Returns None if none selected (means all)."""
+    selected = [mt.upper() for mt in ("lunch", "snacks", "iftar", "event_dinner", "optional_dinner") if _get_option(options, mt)]
+    return selected or None
 
 
 def _handle_meal_update(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
@@ -50,14 +61,13 @@ def _handle_meal_update(interaction: DiscordInteraction, options: list) -> tuple
     if not target_date:
         return _reply("Please provide a date.")
     opt_in_val = _get_option(options, "opt_in")
-    meal_type = _get_option(options, "meal_type")
-    msgs = []
+    meal_types = _collect_meal_types(options)
     if opt_in_val is not None:
         fn = meal_service.opt_in if opt_in_val else meal_service.opt_out
-        msgs.append(fn(target_date, user_id, updated_by=user_id))
-    if meal_type:
-        msgs.append(meal_service.update_meal_type(target_date, user_id, meal_type, updated_by=user_id))
-    return _reply("\n".join(msgs) if msgs else "Nothing to update.")
+        return _reply(fn(target_date, user_id, updated_by=user_id, meal_types=meal_types))
+    if meal_types:
+        return _reply(meal_service.opt_out(target_date, user_id, updated_by=user_id, meal_types=meal_types))
+    return _reply("Nothing to update.")
 
 
 
@@ -110,15 +120,15 @@ def _handle_meal_override(interaction: DiscordInteraction, options: list) -> tup
         return _reply("Please provide both user and date.")
     opt_in_val = _get_option(options, "opt_in")
     location = _get_option(options, "location")
-    meal_type = _get_option(options, "meal_type")
+    meal_types = _collect_meal_types(options)
     msgs = []
     if opt_in_val is not None:
         fn = meal_service.opt_in if opt_in_val else meal_service.opt_out
-        msgs.append(fn(target_date, target_user, updated_by=user_id, bypass_cutoff=True))
+        msgs.append(fn(target_date, target_user, updated_by=user_id, meal_types=meal_types, bypass_cutoff=True))
+    elif meal_types:
+        msgs.append(meal_service.opt_out(target_date, target_user, updated_by=user_id, meal_types=meal_types, bypass_cutoff=True))
     if location:
         msgs.append(meal_service.update_location(target_date, target_user, location, updated_by=user_id, bypass_cutoff=True))
-    if meal_type:
-        msgs.append(meal_service.update_meal_type(target_date, target_user, meal_type, updated_by=user_id, bypass_cutoff=True))
     return _reply("\n".join(msgs) if msgs else "Nothing to update.")
 
 
@@ -133,7 +143,12 @@ def _handle_users_history(interaction: DiscordInteraction, options: list) -> tup
         return _reply(f"No meal history found for <@{target_user}>.")
     lines = [f"**History for <@{target_user}>**"]
     for r in records:
-        meal_status = f"Opted {'in' if r.meal_opt_in else 'out'} ({r.meal_type})"
+        if not r.meal_opt_in:
+            meal_status = "Opted out (all)"
+        elif r.opted_out_meals:
+            meal_status = f"Out: {', '.join(r.opted_out_meals)}"
+        else:
+            meal_status = "Opted in (all)"
         lines.append(f"`{r.date}` — Meal: {meal_status} | Location: {r.work_location}")
     return _reply("\n".join(lines))
 

--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -122,6 +122,22 @@ def _handle_meal_override(interaction: DiscordInteraction, options: list) -> tup
     return _reply("\n".join(msgs) if msgs else "Nothing to update.")
 
 
+def _handle_users_history(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
+    if not _is_team_lead(interaction):
+        return _reply("You do not have permission to use this command.")
+    target_user = _get_option(options, "user")
+    if not target_user:
+        return _reply("Please provide a user.")
+    records = meal_service.get_user_history(target_user)
+    if not records:
+        return _reply(f"No meal history found for <@{target_user}>.")
+    lines = [f"**History for <@{target_user}>**"]
+    for r in records:
+        meal_status = f"Opted {'in' if r.meal_opt_in else 'out'} ({r.meal_type})"
+        lines.append(f"`{r.date}` — Meal: {meal_status} | Location: {r.work_location}")
+    return _reply("\n".join(lines))
+
+
 def _handle_meal_event(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
     action = _get_option(options, "action") or "announce"
     if action == "announce":
@@ -208,6 +224,9 @@ def _route_command(interaction: DiscordInteraction) -> tuple[str, bool]:
 
     if command == "location":
         return _handle_work_location(interaction, options)
+
+    if command == "history":
+        return _handle_users_history(interaction, options)
 
     return _reply("Unknown command.")
 

--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -1,48 +1,19 @@
 from __future__ import annotations
 
-import base64
-import json
 import logging
-import time
 from typing import Any
-
-from nacl.exceptions import BadSignatureError
-from nacl.signing import VerifyKey
 
 from app.config import settings
 from app.models.discord_models import DiscordInteraction
 from app.models.meal_models import MealRecord
-from app.services import headcount_service, meal_service
+from app.services import discord_service, headcount_service, meal_service
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
 
-# Discord interaction types
-_PING = 1
-_APPLICATION_COMMAND = 2
 
-# Discord response types
-_PONG = 1
-_CHANNEL_MESSAGE_WITH_SOURCE = 4
-
-_EPHEMERAL = 64
-
-
-# --------
-# Helpers
-# --------
-
-def _ok(body: dict) -> dict:
-    return {"statusCode": 200, "headers": {"Content-Type": "application/json"}, "body": json.dumps(body)}
-
-
-def _err(status: int, message: str) -> dict:
-    return {"statusCode": status, "headers": {"Content-Type": "application/json"}, "body": json.dumps({"error": message})}
-
-
-def _reply(content: str, ephemeral: bool = True) -> dict:
-    flags = _EPHEMERAL if ephemeral else 0
-    return _ok({"type": _CHANNEL_MESSAGE_WITH_SOURCE, "data": {"content": content, "flags": flags}})
+def _reply(content: str, ephemeral: bool = True) -> tuple[str, bool]:
+    return content, ephemeral
 
 
 def _has_role(interaction: DiscordInteraction, role_id: str) -> bool:
@@ -64,39 +35,7 @@ def _get_option(options: list, name: str) -> Any:
     return None
 
 
-
-# -----------------------
-# Signature verification
-# -----------------------
-
-def _verify_signature(headers: dict, raw_body: bytes) -> bool:
-    sig = headers.get("x-signature-ed25519", "")
-    timestamp = headers.get("x-signature-timestamp", "")
-
-    if not sig or not timestamp:
-        return False
-
-    # Replay-attack protection: reject requests older than 5 minutes
-    try:
-        if abs(time.time() - float(timestamp)) > 300:
-            return False
-    except ValueError:
-        return False
-
-    try:
-        verify_key = VerifyKey(bytes.fromhex(settings.discord_public_key))
-        verify_key.verify(timestamp.encode() + raw_body, bytes.fromhex(sig))
-        return True
-    except (BadSignatureError, Exception):
-        return False
-
-
-
-# ----------------
-# Command routing
-# ----------------
-
-def _handle_meal_status(interaction: DiscordInteraction, options: list) -> dict:
+def _handle_meal_status(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
     from datetime import date as _date
     user_id = interaction.get_user().id
     target_date = _get_option(options, "date") or str(_date.today())
@@ -105,7 +44,7 @@ def _handle_meal_status(interaction: DiscordInteraction, options: list) -> dict:
     return _reply(f"**{target_date}** — {status} | Location: {record.work_location} | Meal: {record.meal_type}")
 
 
-def _handle_meal_update(interaction: DiscordInteraction, options: list) -> dict:
+def _handle_meal_update(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
     user_id = interaction.get_user().id
     target_date = _get_option(options, "date")
     if not target_date:
@@ -121,7 +60,7 @@ def _handle_meal_update(interaction: DiscordInteraction, options: list) -> dict:
     return _reply("\n".join(msgs) if msgs else "Nothing to update.")
 
 
-def _handle_meal_location(interaction: DiscordInteraction, options: list) -> dict:
+def _handle_meal_location(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
     user_id = interaction.get_user().id
     target_date = _get_option(options, "date")
     location = _get_option(options, "location")
@@ -130,7 +69,7 @@ def _handle_meal_location(interaction: DiscordInteraction, options: list) -> dic
     return _reply(meal_service.update_location(target_date, user_id, location, updated_by=user_id))
 
 
-def _handle_meal_optout(interaction: DiscordInteraction, options: list) -> dict:
+def _handle_meal_optout(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
     user_id = interaction.get_user().id
     target_date = _get_option(options, "date")
     if not target_date:
@@ -140,7 +79,7 @@ def _handle_meal_optout(interaction: DiscordInteraction, options: list) -> dict:
     return _reply(meal_service.opt_out(target_date, user_id, updated_by=user_id))
 
 
-def _handle_meal_summary(interaction: DiscordInteraction, options: list) -> dict:
+def _handle_meal_summary(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
     if not _is_team_lead(interaction):
         return _reply("You do not have permission to use this command.")
     target_date = _get_option(options, "date")
@@ -154,7 +93,7 @@ def _handle_meal_summary(interaction: DiscordInteraction, options: list) -> dict
     )
 
 
-def _handle_meal_summary_all(interaction: DiscordInteraction, options: list) -> dict:
+def _handle_meal_summary_all(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
     if not _is_admin(interaction):
         return _reply("You do not have permission to use this command.")
     target_date = _get_option(options, "date")
@@ -169,7 +108,7 @@ def _handle_meal_summary_all(interaction: DiscordInteraction, options: list) -> 
     )
 
 
-def _handle_meal_override(interaction: DiscordInteraction, options: list) -> dict:
+def _handle_meal_override(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
     if not _is_admin(interaction):
         return _reply("You do not have permission to use this command.")
     user_id = interaction.get_user().id
@@ -191,7 +130,7 @@ def _handle_meal_override(interaction: DiscordInteraction, options: list) -> dic
     return _reply("\n".join(msgs) if msgs else "Nothing to update.")
 
 
-def _handle_meal_event(interaction: DiscordInteraction, options: list) -> dict:
+def _handle_meal_event(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
     action = _get_option(options, "action") or "announce"
     if action == "announce":
         if not _is_admin(interaction):
@@ -211,28 +150,27 @@ def _handle_meal_event(interaction: DiscordInteraction, options: list) -> dict:
 
 
 _MEAL_HANDLERS = {
-    "status": _handle_meal_status,
-    "update": _handle_meal_update,
-    "location": _handle_meal_location,
-    "optout": _handle_meal_optout,
-    "summary": _handle_meal_summary,
+    "status":      _handle_meal_status,
+    "update":      _handle_meal_update,
+    "location":    _handle_meal_location,
+    "optout":      _handle_meal_optout,
+    "summary":     _handle_meal_summary,
     "summary-all": _handle_meal_summary_all,
-    "override": _handle_meal_override,
-    "event": _handle_meal_event,
+    "override":    _handle_meal_override,
+    "event":       _handle_meal_event,
 }
 
 
-def _handle_meal(interaction: DiscordInteraction, subcommand: str, options: list) -> dict:
+def _handle_meal(interaction: DiscordInteraction, subcommand: str, options: list) -> tuple[str, bool]:
     handler_fn = _MEAL_HANDLERS.get(subcommand)
     if not handler_fn:
         return _reply("Unknown subcommand.")
     return handler_fn(interaction, options)
 
 
-def _handle_special_day(interaction: DiscordInteraction, subcommand: str, options: list) -> dict:
+def _handle_special_day(interaction: DiscordInteraction, subcommand: str, options: list) -> tuple[str, bool]:
     if not _is_admin(interaction):
         return _reply("You do not have permission to use this command.")
-
     if subcommand == "view":
         target_date = _get_option(options, "date")
         if not target_date:
@@ -242,21 +180,19 @@ def _handle_special_day(interaction: DiscordInteraction, subcommand: str, option
         if event:
             return _reply(f"**{target_date}** is a special event day: _{event.description}_")
         return _reply(f"**{target_date}** is not a configured special day.")
-
     return _reply("Unknown subcommand.")
 
 
-def _route_command(interaction: DiscordInteraction) -> dict:
+def _route_command(interaction: DiscordInteraction) -> tuple[str, bool]:
     if not interaction.data:
         return _reply("No interaction data.")
 
     command = interaction.data.name
     options = interaction.data.options
 
-    # Resolve subcommand and its options
     subcommand = None
     sub_options: list = []
-    if options and options[0].type == 1:  # SUB_COMMAND type
+    if options and options[0].type == 1:
         subcommand = options[0].name
         sub_options = options[0].options
 
@@ -273,55 +209,17 @@ def _route_command(interaction: DiscordInteraction) -> dict:
     return _reply("Unknown command.")
 
 
-
-# -------------------
-# Lambda entry point
-# -------------------
-
-def handler(event: dict, context: Any) -> dict:
-    method = event.get("requestContext", {}).get("http", {}).get("method", "")
-    path = event.get("rawPath", "")
-
-    # Health check
-    if method == "GET" and path == "/health":
-        return _ok({"status": "ok"})
-
-    if method != "POST" or path != "/interactions":
-        return _err(404, "Not found")
-
-    # Decode body
-    body_str: str = event.get("body", "") or ""
-    if event.get("isBase64Encoded"):
-        raw_body = base64.b64decode(body_str)
-    else:
-        raw_body = body_str.encode()
-
-    headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
-
-    # Verify Ed25519 signature
-    if not _verify_signature(headers, raw_body):
-        logger.warning("Invalid signature")
-        return _err(401, "Invalid request signature")
-
-    payload = json.loads(raw_body)
-
-    # Discord PING handshake
-    if payload.get("type") == _PING:
-        return _ok({"type": _PONG})
-
-    # Guild authorization guard
-    guild_id = payload.get("guild_id")
-    if guild_id != settings.authorized_guild_id:
-        logger.warning("Unauthorized guild: %s", guild_id)
-        return _err(401, "Unauthorized guild")
-
-    if payload.get("type") != _APPLICATION_COMMAND:
-        return _err(400, "Unsupported interaction type")
-
+def handler(event: dict, context: Any) -> None:
     try:
-        interaction = DiscordInteraction(**payload)
+        interaction = DiscordInteraction(**event)
     except Exception as exc:
         logger.error("Failed to parse interaction payload: %s", exc)
-        return _err(400, "Invalid interaction payload")
+        return
 
-    return _route_command(interaction)
+    try:
+        content, ephemeral = _route_command(interaction)
+    except Exception as exc:
+        logger.error("Unhandled error routing command: %s", exc)
+        content, ephemeral = "An unexpected error occurred. Please try again.", True
+
+    discord_service.send_followup(interaction.token, content, ephemeral=ephemeral)

--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -77,7 +77,7 @@ def _handle_meal_optout(interaction: DiscordInteraction, options: list) -> tuple
     if not target_date:
         return _reply("Please provide a date.")
     if not meal_service.is_event_day(target_date):
-        return _reply(f"{target_date} is not an event day. Use `/meal update` or `/location` to change your meal preference.")
+        return _reply(f"{target_date} is not an event day. Use `/meal update` or `/location set` to change your meal preference.")
     return _reply(meal_service.opt_out(target_date, user_id, updated_by=user_id))
 
 
@@ -181,6 +181,24 @@ def _handle_work_location(interaction: DiscordInteraction, options: list) -> tup
     return _reply(meal_service.update_location(target_date, user_id, location, updated_by=user_id))
 
 
+def _handle_location_override(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
+    if not _is_admin(interaction):
+        return _reply("You do not have permission to use this command.")
+    user_id = interaction.get_user().id
+    target_user = _get_option(options, "user")
+    target_date = _get_option(options, "date")
+    location = _get_option(options, "location")
+    if not target_user or not target_date or not location:
+        return _reply("Please provide user, date, and location.")
+    return _reply(meal_service.update_location(target_date, target_user, location, updated_by=user_id, bypass_cutoff=True))
+
+
+_LOCATION_HANDLERS = {
+    "set":      _handle_work_location,
+    "override": _handle_location_override,
+}
+
+
 _MEAL_HANDLERS = {
     "status":      _handle_meal_status,
     "update":      _handle_meal_update,
@@ -238,7 +256,12 @@ def _route_command(interaction: DiscordInteraction) -> tuple[str, bool]:
         return _handle_special_day(interaction, subcommand, sub_options)
 
     if command == "location":
-        return _handle_work_location(interaction, options)
+        if not subcommand:
+            return _reply("Please specify a subcommand.")
+        handler_fn = _LOCATION_HANDLERS.get(subcommand)
+        if not handler_fn:
+            return _reply("Unknown subcommand.")
+        return handler_fn(interaction, sub_options)
 
     if command == "history":
         return _handle_users_history(interaction, options)

--- a/Task-2/app/models/meal_models.py
+++ b/Task-2/app/models/meal_models.py
@@ -9,8 +9,8 @@ MealType = Literal["LUNCH", "SNACKS", "IFTAR", "EVENT_DINNER", "OPTIONAL_DINNER"
 
 
 class MealRecord(BaseModel):
-    date: str                               # YYYY-MM-DD — partition key
-    user_id: str                            # Discord snowflake — sort key
+    date: str                               # YYYY-MM-DD
+    user_id: str                            # Discord snowflake
     meal_opt_in: bool = True
     work_location: WorkLocation = "OFFICE"
     meal_type: MealType = "LUNCH"
@@ -18,41 +18,46 @@ class MealRecord(BaseModel):
     updated_by: str = ""
 
     @classmethod
-    def from_dynamo(cls, item: dict) -> MealRecord:
+    def from_dynamo_pair(cls, meal_item: dict | None, loc_item: dict | None) -> MealRecord | None:
+        """Merge a Meal Participation item and a Work Location item into a MealRecord."""
+        if meal_item is None and loc_item is None:
+            return None
+        base = meal_item or loc_item
         return cls(
-            date=item["date"],
-            user_id=item["user_id"],
-            meal_opt_in=item.get("meal_opt_in", True),
-            work_location=item.get("work_location", "OFFICE"),
-            meal_type=item.get("meal_type", "LUNCH"),
-            updated_at=item.get("updated_at", ""),
-            updated_by=item.get("updated_by", ""),
+            date=base["date"],
+            user_id=base["user_id"],
+            meal_opt_in=(meal_item or {}).get("meal_opt_in", True),
+            work_location=(loc_item or {}).get("work_location", "OFFICE"),
+            meal_type=(meal_item or {}).get("meal_type", "LUNCH"),
+            updated_at=base.get("updated_at", ""),
+            updated_by=base.get("updated_by", ""),
         )
 
-    def to_dynamo(self) -> dict:
-        """Item for mhp-meal-records: pk=DATE#{date}, sk=USER#{user_id}."""
+    def to_meal_dynamo(self) -> dict:
+        """Meal Participation item: PK=MEAL#<date>, SK=USER#<userId>."""
         return {
-            "pk": f"DATE#{self.date}",
-            "sk": f"USER#{self.user_id}",
+            "PK": f"MEAL#{self.date}",
+            "SK": f"USER#{self.user_id}",
+            "GSI1PK": f"USER#{self.user_id}",
+            "GSI1SK": f"MEAL#{self.date}",
             "date": self.date,
             "user_id": self.user_id,
             "meal_opt_in": self.meal_opt_in,
-            "work_location": self.work_location,
             "meal_type": self.meal_type,
             "updated_at": self.updated_at,
             "updated_by": self.updated_by,
         }
 
-    def to_user_history_dynamo(self) -> dict:
-        """Item for mhp-user-history: pk=USER#{user_id}, sk=DATE#{date}."""
+    def to_loc_dynamo(self) -> dict:
+        """Work Location item: PK=LOC#<date>, SK=USER#<userId>."""
         return {
-            "pk": f"USER#{self.user_id}",
-            "sk": f"DATE#{self.date}",
+            "PK": f"LOC#{self.date}",
+            "SK": f"USER#{self.user_id}",
+            "GSI1PK": f"USER#{self.user_id}",
+            "GSI1SK": f"LOC#{self.date}",
             "date": self.date,
             "user_id": self.user_id,
-            "meal_opt_in": self.meal_opt_in,
             "work_location": self.work_location,
-            "meal_type": self.meal_type,
             "updated_at": self.updated_at,
             "updated_by": self.updated_by,
         }

--- a/Task-2/app/models/meal_models.py
+++ b/Task-2/app/models/meal_models.py
@@ -5,7 +5,6 @@ from typing import Literal
 from pydantic import BaseModel
 
 WorkLocation = Literal["OFFICE", "WFH"]
-MealType = Literal["LUNCH", "SNACKS", "IFTAR", "EVENT_DINNER", "OPTIONAL_DINNER"]
 
 
 class MealRecord(BaseModel):
@@ -13,7 +12,7 @@ class MealRecord(BaseModel):
     user_id: str                            # Discord snowflake
     meal_opt_in: bool = True
     work_location: WorkLocation = "OFFICE"
-    meal_type: MealType = "LUNCH"
+    opted_out_meals: list[str] = []
     updated_at: str = ""
     updated_by: str = ""
 
@@ -28,7 +27,7 @@ class MealRecord(BaseModel):
             user_id=base["user_id"],
             meal_opt_in=(meal_item or {}).get("meal_opt_in", True),
             work_location=(loc_item or {}).get("work_location", "OFFICE"),
-            meal_type=(meal_item or {}).get("meal_type", "LUNCH"),
+            opted_out_meals=(meal_item or {}).get("opted_out_meals", []),
             updated_at=base.get("updated_at", ""),
             updated_by=base.get("updated_by", ""),
         )
@@ -43,7 +42,7 @@ class MealRecord(BaseModel):
             "date": self.date,
             "user_id": self.user_id,
             "meal_opt_in": self.meal_opt_in,
-            "meal_type": self.meal_type,
+            "opted_out_meals": self.opted_out_meals,
             "updated_at": self.updated_at,
             "updated_by": self.updated_by,
         }

--- a/Task-2/app/router.py
+++ b/Task-2/app/router.py
@@ -1,0 +1,96 @@
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import time
+from typing import Any
+
+import boto3
+from nacl.exceptions import BadSignatureError
+from nacl.signing import VerifyKey
+
+from app.config import settings
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+_PING = 1
+_APPLICATION_COMMAND = 2
+_PONG = 1
+_DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE = 5
+_EPHEMERAL = 64
+
+_lambda_client = boto3.client("lambda", region_name=settings.aws_region)
+
+
+def _ok(body: dict) -> dict:
+    return {"statusCode": 200, "headers": {"Content-Type": "application/json"}, "body": json.dumps(body)}
+
+
+def _err(status: int, message: str) -> dict:
+    return {"statusCode": status, "headers": {"Content-Type": "application/json"}, "body": json.dumps({"error": message})}
+
+
+def _verify_signature(headers: dict, raw_body: bytes) -> bool:
+    sig = headers.get("x-signature-ed25519", "")
+    timestamp = headers.get("x-signature-timestamp", "")
+
+    if not sig or not timestamp:
+        return False
+
+    try:
+        if abs(time.time() - float(timestamp)) > 300:
+            return False
+    except ValueError:
+        return False
+
+    try:
+        verify_key = VerifyKey(bytes.fromhex(settings.discord_public_key))
+        verify_key.verify(timestamp.encode() + raw_body, bytes.fromhex(sig))
+        return True
+    except (BadSignatureError, Exception):
+        return False
+
+
+def handler(event: dict, context: Any) -> dict:
+    method = event.get("requestContext", {}).get("http", {}).get("method", "")
+    path = event.get("rawPath", "")
+
+    if method == "GET" and path == "/health":
+        return _ok({"status": "ok"})
+
+    if method != "POST" or path != "/interactions":
+        return _err(404, "Not found")
+
+    body_str: str = event.get("body", "") or ""
+    raw_body = base64.b64decode(body_str) if event.get("isBase64Encoded") else body_str.encode()
+    headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
+
+    if not _verify_signature(headers, raw_body):
+        logger.warning("Invalid signature")
+        return _err(401, "Invalid request signature")
+
+    payload = json.loads(raw_body)
+
+    if payload.get("type") == _PING:
+        return _ok({"type": _PONG})
+
+    if payload.get("guild_id") != settings.authorized_guild_id:
+        logger.warning("Unauthorized guild: %s", payload.get("guild_id"))
+        return _err(401, "Unauthorized guild")
+
+    if payload.get("type") != _APPLICATION_COMMAND:
+        return _err(400, "Unsupported interaction type")
+
+    _lambda_client.invoke(
+        FunctionName=settings.command_lambda_name,
+        InvocationType="Event",
+        Payload=json.dumps(payload).encode(),
+    )
+    logger.info("Dispatched command=%s to %s", payload.get("data", {}).get("name"), settings.command_lambda_name)
+
+    return _ok({
+        "type": _DEFERRED_CHANNEL_MESSAGE_WITH_SOURCE,
+        "data": {"flags": _EPHEMERAL},
+    })

--- a/Task-2/app/router.py
+++ b/Task-2/app/router.py
@@ -71,7 +71,11 @@ def handler(event: dict, context: Any) -> dict:
         logger.warning("Invalid signature")
         return _err(401, "Invalid request signature")
 
-    payload = json.loads(raw_body)
+    try:
+        payload = json.loads(raw_body)
+    except json.JSONDecodeError:
+        logger.warning("Invalid JSON in request body")
+        return _err(400, "Invalid request body")
 
     if payload.get("type") == _PING:
         return _ok({"type": _PONG})

--- a/Task-2/app/router.py
+++ b/Task-2/app/router.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import base64
+import binascii
 import json
 import logging
 import time
@@ -49,7 +50,7 @@ def _verify_signature(headers: dict, raw_body: bytes) -> bool:
         verify_key = VerifyKey(bytes.fromhex(settings.discord_public_key))
         verify_key.verify(timestamp.encode() + raw_body, bytes.fromhex(sig))
         return True
-    except (BadSignatureError, Exception):
+    except (BadSignatureError, ValueError):
         return False
 
 
@@ -64,7 +65,10 @@ def handler(event: dict, context: Any) -> dict:
         return _err(404, "Not found")
 
     body_str: str = event.get("body", "") or ""
-    raw_body = base64.b64decode(body_str) if event.get("isBase64Encoded") else body_str.encode()
+    try:
+        raw_body = base64.b64decode(body_str) if event.get("isBase64Encoded") else body_str.encode()
+    except binascii.Error:
+        return _err(400, "Invalid request body")
     headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
 
     if not _verify_signature(headers, raw_body):

--- a/Task-2/app/services/meal_service.py
+++ b/Task-2/app/services/meal_service.py
@@ -23,19 +23,21 @@ _EVENTS_PATH = Path(__file__).parent.parent.parent / "config" / "events.json"
 _serializer = TypeSerializer()
 _WFH_MONTHLY_LIMIT = 5
 
+# Loaded once at module level — captured in SnapStart snapshot
+with _EVENTS_PATH.open() as _f:
+    _EVENTS: list[EventConfig] = [EventConfig(**e) for e in json.load(_f)]
+
 
 def _serialize(item: dict) -> dict:
-    """Convert a plain Python dict to DynamoDB wire format for use with transact_write_items."""
     return {k: _serializer.serialize(v) for k, v in item.items()}
 
 
 def _load_events() -> list[EventConfig]:
-    with _EVENTS_PATH.open() as f:
-        return [EventConfig(**e) for e in json.load(f)]
+    return _EVENTS
 
 
 def is_event_day(date: str) -> bool:
-    return any(e.date == date for e in _load_events())
+    return any(e.date == date for e in _EVENTS)
 
 
 def check_cutoff(target_date: str, bypass: bool = False) -> str | None:

--- a/Task-2/app/services/meal_service.py
+++ b/Task-2/app/services/meal_service.py
@@ -8,7 +8,7 @@ from zoneinfo import ZoneInfo
 
 import boto3
 from boto3.dynamodb.conditions import Key
-from boto3.dynamodb.types import TypeSerializer
+from boto3.dynamodb.types import TypeDeserializer, TypeSerializer
 from botocore.exceptions import ClientError
 
 from app.config import settings
@@ -21,6 +21,7 @@ _table = _dynamodb.Table(settings.dynamodb_table)
 
 _EVENTS_PATH = Path(__file__).parent.parent.parent / "config" / "events.json"
 _serializer = TypeSerializer()
+_deserializer = TypeDeserializer()
 _WFH_MONTHLY_LIMIT = 5
 
 # Loaded once at module level — captured in SnapStart snapshot
@@ -70,11 +71,28 @@ def check_cutoff(target_date: str, bypass: bool = False) -> str | None:
 
 def get_record(date: str, user_id: str) -> MealRecord | None:
     try:
-        meal_resp = _table.get_item(Key={"PK": f"MEAL#{date}", "SK": f"USER#{user_id}"})
-        loc_resp = _table.get_item(Key={"PK": f"LOC#{date}", "SK": f"USER#{user_id}"})
-        return MealRecord.from_dynamo_pair(meal_resp.get("Item"), loc_resp.get("Item"))
+        response = _dynamodb.meta.client.batch_get_item(
+            RequestItems={
+                settings.dynamodb_table: {
+                    "Keys": [
+                        {"PK": {"S": f"MEAL#{date}"}, "SK": {"S": f"USER#{user_id}"}},
+                        {"PK": {"S": f"LOC#{date}"}, "SK": {"S": f"USER#{user_id}"}},
+                    ]
+                }
+            }
+        )
+        items = response.get("Responses", {}).get(settings.dynamodb_table, [])
+        meal_item = None
+        loc_item = None
+        for raw in items:
+            item = {k: _deserializer.deserialize(v) for k, v in raw.items()}
+            if item["PK"].startswith("MEAL#"):
+                meal_item = item
+            elif item["PK"].startswith("LOC#"):
+                loc_item = item
+        return MealRecord.from_dynamo_pair(meal_item, loc_item)
     except ClientError as e:
-        logger.error("DynamoDB get_item failed for date=%s user_id=%s: %s", date, user_id, e)
+        logger.error("DynamoDB batch_get_item failed for date=%s user_id=%s: %s", date, user_id, e)
         raise
 
 

--- a/Task-2/app/services/meal_service.py
+++ b/Task-2/app/services/meal_service.py
@@ -137,14 +137,18 @@ def update_location(
 
     record = get_record(date, user_id) or MealRecord(date=date, user_id=user_id)
     record.work_location = location
+    if location == "WFH":
+        record.meal_opt_in = False
     record.updated_by = updated_by
     upsert_record(record)
 
     msg = f"Work location set to **{location}** for {date}."
-    if location == "WFH" and not bypass_cutoff:
-        wfh_count = count_wfh_days_this_month(user_id, date[:7])
-        if wfh_count >= _WFH_MONTHLY_LIMIT:
-            msg += f"\n⚠️ You have used {wfh_count} WFH day(s) this month (soft limit: {_WFH_MONTHLY_LIMIT}). Please coordinate with your team lead."
+    if location == "WFH":
+        msg += "\nYou have been automatically opted **out** of all meals for this day."
+        if not bypass_cutoff:
+            wfh_count = count_wfh_days_this_month(user_id, date[:7])
+            if wfh_count >= _WFH_MONTHLY_LIMIT:
+                msg += f"\n⚠️ You have used {wfh_count} WFH day(s) this month (soft limit: {_WFH_MONTHLY_LIMIT}). Please coordinate with your team lead."
     return msg
 
 

--- a/Task-2/app/services/meal_service.py
+++ b/Task-2/app/services/meal_service.py
@@ -23,6 +23,7 @@ _EVENTS_PATH = Path(__file__).parent.parent.parent / "config" / "events.json"
 _serializer = TypeSerializer()
 _deserializer = TypeDeserializer()
 _WFH_MONTHLY_LIMIT = 5
+VALID_MEAL_TYPES = {"LUNCH", "SNACKS", "IFTAR", "EVENT_DINNER", "OPTIONAL_DINNER"}
 
 # Loaded once at module level — captured in SnapStart snapshot
 with _EVENTS_PATH.open() as _f:
@@ -111,31 +112,43 @@ def upsert_record(record: MealRecord) -> None:
         raise
 
 
-def opt_in(date: str, user_id: str, updated_by: str, bypass_cutoff: bool = False) -> str:
+def opt_in(date: str, user_id: str, updated_by: str, meal_types: list[str] | None = None, bypass_cutoff: bool = False) -> str:
     err = check_cutoff(date, bypass=bypass_cutoff)
     if err:
         return err
 
     record = get_record(date, user_id) or MealRecord(date=date, user_id=user_id)
-    record.meal_opt_in = True
+    if meal_types:
+        record.opted_out_meals = [m for m in record.opted_out_meals if m not in meal_types]
+    else:
+        record.meal_opt_in = True
+        record.opted_out_meals = []
     record.updated_by = updated_by
     upsert_record(record)
-    return f"You are opted **in** for the meal on {date}."
+    if meal_types:
+        return f"You are opted **in** for **{', '.join(meal_types)}** on {date}."
+    return f"You are opted **in** for all meals on {date}."
 
 
-def opt_out(date: str, user_id: str, updated_by: str, bypass_cutoff: bool = False) -> str:
+def opt_out(date: str, user_id: str, updated_by: str, meal_types: list[str] | None = None, bypass_cutoff: bool = False) -> str:
     err = check_cutoff(date, bypass=bypass_cutoff)
     if err:
         return err
 
     record = get_record(date, user_id) or MealRecord(date=date, user_id=user_id)
-    record.meal_opt_in = False
+    if meal_types:
+        record.opted_out_meals = list(set(record.opted_out_meals) | set(meal_types))
+    else:
+        record.meal_opt_in = False
+        record.opted_out_meals = []
     record.updated_by = updated_by
     upsert_record(record)
 
+    if meal_types:
+        return f"You have opted **out** of **{', '.join(meal_types)}** on {date}."
     if is_event_day(date):
         return f"You have opted out of the event meal on {date}."
-    return f"You have opted **out** of the meal on {date}."
+    return f"You have opted **out** of all meals on {date}."
 
 
 def update_location(
@@ -170,27 +183,6 @@ def update_location(
     return msg
 
 
-def update_meal_type(
-    date: str,
-    user_id: str,
-    meal_type: str,
-    updated_by: str,
-    bypass_cutoff: bool = False,
-) -> str:
-    VALID_MEAL_TYPES = {"LUNCH", "SNACKS", "IFTAR", "EVENT_DINNER", "OPTIONAL_DINNER"}
-    meal_type = meal_type.upper().replace(" ", "_")
-    if meal_type not in VALID_MEAL_TYPES:
-        return f"Invalid meal type. Choose from: {', '.join(sorted(VALID_MEAL_TYPES))}."
-
-    err = check_cutoff(date, bypass=bypass_cutoff)
-    if err:
-        return err
-
-    record = get_record(date, user_id) or MealRecord(date=date, user_id=user_id)
-    record.meal_type = meal_type
-    record.updated_by = updated_by
-    upsert_record(record)
-    return f"Meal type set to **{meal_type}** for {date}."
 
 
 def count_wfh_days_this_month(user_id: str, month_prefix: str) -> int:

--- a/Task-2/app/services/meal_service.py
+++ b/Task-2/app/services/meal_service.py
@@ -17,8 +17,7 @@ from app.models.meal_models import EventConfig, MealRecord
 logger = logging.getLogger(__name__)
 
 _dynamodb = boto3.resource("dynamodb", region_name=settings.aws_region)
-_meal_table = _dynamodb.Table(settings.dynamodb_meal_table)
-_history_table = _dynamodb.Table(settings.dynamodb_user_history_table)
+_table = _dynamodb.Table(settings.dynamodb_table)
 
 _EVENTS_PATH = Path(__file__).parent.parent.parent / "config" / "events.json"
 _serializer = TypeSerializer()
@@ -69,24 +68,22 @@ def check_cutoff(target_date: str, bypass: bool = False) -> str | None:
 
 def get_record(date: str, user_id: str) -> MealRecord | None:
     try:
-        response = _meal_table.get_item(
-            Key={"pk": f"DATE#{date}", "sk": f"USER#{user_id}"}
-        )
-        item = response.get("Item")
-        return MealRecord.from_dynamo(item) if item else None
+        meal_resp = _table.get_item(Key={"PK": f"MEAL#{date}", "SK": f"USER#{user_id}"})
+        loc_resp = _table.get_item(Key={"PK": f"LOC#{date}", "SK": f"USER#{user_id}"})
+        return MealRecord.from_dynamo_pair(meal_resp.get("Item"), loc_resp.get("Item"))
     except ClientError as e:
         logger.error("DynamoDB get_item failed for date=%s user_id=%s: %s", date, user_id, e)
         raise
 
 
 def upsert_record(record: MealRecord) -> None:
-    """Write-through: atomic write to mhp-meal-records and mhp-user-history via TransactWriteItems."""
+    """Atomically write Meal Participation and Work Location items to MHP_Table."""
     record.updated_at = datetime.now(ZoneInfo(settings.timezone)).isoformat()
     try:
         _dynamodb.meta.client.transact_write_items(
             TransactItems=[
-                {"Put": {"TableName": settings.dynamodb_meal_table, "Item": _serialize(record.to_dynamo())}},
-                {"Put": {"TableName": settings.dynamodb_user_history_table, "Item": _serialize(record.to_user_history_dynamo())}},
+                {"Put": {"TableName": settings.dynamodb_table, "Item": _serialize(record.to_meal_dynamo())}},
+                {"Put": {"TableName": settings.dynamodb_table, "Item": _serialize(record.to_loc_dynamo())}},
             ]
         )
     except ClientError as e:
@@ -173,38 +170,58 @@ def update_meal_type(
 
 
 def count_wfh_days_this_month(user_id: str, month_prefix: str) -> int:
-    """Count WFH records for a user in a given calendar month (YYYY-MM)."""
+    """Count WFH Work Location items for a user in a given calendar month (YYYY-MM).
+
+    Queries GSI1: GSI1PK=USER#<userId>, GSI1SK begins_with LOC#<YYYY-MM>.
+    """
     try:
-        response = _history_table.query(
+        response = _table.query(
+            IndexName="GSI1",
             KeyConditionExpression=(
-                Key("pk").eq(f"USER#{user_id}") & Key("sk").begins_with(f"DATE#{month_prefix}")
-            )
+                Key("GSI1PK").eq(f"USER#{user_id}") & Key("GSI1SK").begins_with(f"LOC#{month_prefix}")
+            ),
         )
         return sum(1 for item in response.get("Items", []) if item.get("work_location") == "WFH")
     except ClientError as e:
-        logger.error("DynamoDB query failed for WFH count user_id=%s month=%s: %s", user_id, month_prefix, e)
+        logger.error("DynamoDB GSI1 query failed for WFH count user_id=%s month=%s: %s", user_id, month_prefix, e)
         return 0
 
 
 def get_records_for_date(date: str) -> list[MealRecord]:
-    """Query mhp-meal-records by date partition key."""
+    """Query MHP_Table for all meal and location items on a given date, then merge by user."""
     try:
-        response = _meal_table.query(
-            KeyConditionExpression=Key("pk").eq(f"DATE#{date}")
-        )
-        return [MealRecord.from_dynamo(item) for item in response.get("Items", [])]
+        meal_response = _table.query(KeyConditionExpression=Key("PK").eq(f"MEAL#{date}"))
+        loc_response = _table.query(KeyConditionExpression=Key("PK").eq(f"LOC#{date}"))
+
+        meal_by_user = {item["user_id"]: item for item in meal_response.get("Items", [])}
+        loc_by_user = {item["user_id"]: item for item in loc_response.get("Items", [])}
+
+        all_user_ids = meal_by_user.keys() | loc_by_user.keys()
+        return [
+            MealRecord.from_dynamo_pair(meal_by_user.get(uid), loc_by_user.get(uid))
+            for uid in all_user_ids
+        ]
     except ClientError as e:
         logger.error("DynamoDB query failed for date=%s: %s", date, e)
         return []
 
 
 def get_user_history(user_id: str) -> list[MealRecord]:
-    """Query mhp-user-history for all records belonging to a user."""
+    """Query GSI1 for all meal and location items belonging to a user, then merge by date."""
     try:
-        response = _history_table.query(
-            KeyConditionExpression=Key("pk").eq(f"USER#{user_id}")
+        response = _table.query(
+            IndexName="GSI1",
+            KeyConditionExpression=Key("GSI1PK").eq(f"USER#{user_id}"),
         )
-        return [MealRecord.from_dynamo(item) for item in response.get("Items", [])]
+        items = response.get("Items", [])
+        meal_by_date = {item["date"]: item for item in items if item.get("GSI1SK", "").startswith("MEAL#")}
+        loc_by_date = {item["date"]: item for item in items if item.get("GSI1SK", "").startswith("LOC#")}
+
+        all_dates = meal_by_date.keys() | loc_by_date.keys()
+        return [
+            MealRecord.from_dynamo_pair(meal_by_date.get(d), loc_by_date.get(d))
+            for d in all_dates
+        ]
     except ClientError as e:
-        logger.error("DynamoDB query failed for user_id=%s: %s", user_id, e)
+        logger.error("DynamoDB GSI1 query failed for user_id=%s: %s", user_id, e)
         return []

--- a/Task-2/build.sh
+++ b/Task-2/build.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -e
+
+PACKAGE_DIR="package"
+ZIP_FILE="lambda.zip"
+
+echo "Cleaning previous build..."
+rm -rf "$PACKAGE_DIR" "$ZIP_FILE"
+
+echo "Installing dependencies..."
+python -m pip install -r requirements.txt -t "$PACKAGE_DIR/" --quiet --no-cache-dir
+
+echo "Copying app..."
+cp -r app     "$PACKAGE_DIR/app"
+cp -r config  "$PACKAGE_DIR/config"
+
+echo "Done — select everything inside the '$PACKAGE_DIR/' folder and zip it manually."

--- a/Task-2/build.sh
+++ b/Task-2/build.sh
@@ -8,7 +8,12 @@ echo "Cleaning previous build..."
 rm -rf "$PACKAGE_DIR" "$ZIP_FILE"
 
 echo "Installing dependencies..."
-python -m pip install -r requirements.txt -t "$PACKAGE_DIR/" --quiet --no-cache-dir
+python -m pip install -r requirements.txt -t "$PACKAGE_DIR/" \
+  --no-cache-dir \
+  --platform manylinux2014_aarch64 \
+  --implementation cp \
+  --python-version 3.12 \
+  --only-binary=:all:
 
 echo "Copying app..."
 cp -r app     "$PACKAGE_DIR/app"

--- a/Task-2/docs/technical_spec.md
+++ b/Task-2/docs/technical_spec.md
@@ -418,7 +418,8 @@ Registered via the Discord Developer Portal. Each command maps to a handler insi
 | Command | Permission | Description |
 | --- | --- | --- |
 | `/meal status [date]` | Employee | Show own meal opt-in and work location for a date (defaults to today). |
-| `/meal update` | Employee | Update own meal opt-in, work location, or meal type for a date. |
+| `/meal update` | Employee | Update own meal opt-in or meal type for a date. |
+| `/meal location <date> <location>` | Employee | Set own work location (OFFICE or WFH) for a date. |
 | `/meal optout <date>` | Employee | Opt out of an event meal for a specific date. |
 | `/meal summary <date>` | Team Lead | Show team headcount summary for a date. |
 | `/meal summary-all <date>` | Admin | Show org-wide headcount summary for a date. |

--- a/Task-2/register_commands.py
+++ b/Task-2/register_commands.py
@@ -46,27 +46,20 @@ COMMANDS = [
                     }
                 ],
             },
-            # /meal update date [opt_in] [meal_type]
+            # /meal update <date> [opt_in] [lunch] [snacks] [iftar] [event_dinner] [optional_dinner]
+            # No meal types selected = applies to all. Specific types = opt out of only those.
             {
                 "type": 1,
                 "name": "update",
-                "description": "Update your opt-in status or meal type for a date",
+                "description": "Update your meal opt-in/out for a date",
                 "options": [
                     {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True},
                     {"type": _BOOL, "name": "opt_in", "description": "Opt in (true) or out (false)", "required": False},
-                    {
-                        "type": _STR,
-                        "name": "meal_type",
-                        "description": "Meal type",
-                        "required": False,
-                        "choices": [
-                            {"name": "Lunch", "value": "LUNCH"},
-                            {"name": "Snacks", "value": "SNACKS"},
-                            {"name": "Iftar", "value": "IFTAR"},
-                            {"name": "Event Dinner", "value": "EVENT_DINNER"},
-                            {"name": "Optional Dinner", "value": "OPTIONAL_DINNER"},
-                        ],
-                    },
+                    {"type": _BOOL, "name": "lunch", "description": "Select Lunch", "required": False},
+                    {"type": _BOOL, "name": "snacks", "description": "Select Snacks", "required": False},
+                    {"type": _BOOL, "name": "iftar", "description": "Select Iftar", "required": False},
+                    {"type": _BOOL, "name": "event_dinner", "description": "Select Event Dinner", "required": False},
+                    {"type": _BOOL, "name": "optional_dinner", "description": "Select Optional Dinner", "required": False},
                 ],
             },
             # /meal optout date
@@ -115,19 +108,11 @@ COMMANDS = [
                             {"name": "WFH", "value": "WFH"},
                         ],
                     },
-                    {
-                        "type": _STR,
-                        "name": "meal_type",
-                        "description": "Meal type",
-                        "required": False,
-                        "choices": [
-                            {"name": "Lunch", "value": "LUNCH"},
-                            {"name": "Snacks", "value": "SNACKS"},
-                            {"name": "Iftar", "value": "IFTAR"},
-                            {"name": "Event Dinner", "value": "EVENT_DINNER"},
-                            {"name": "Optional Dinner", "value": "OPTIONAL_DINNER"},
-                        ],
-                    },
+                    {"type": _BOOL, "name": "lunch", "description": "Select Lunch", "required": False},
+                    {"type": _BOOL, "name": "snacks", "description": "Select Snacks", "required": False},
+                    {"type": _BOOL, "name": "iftar", "description": "Select Iftar", "required": False},
+                    {"type": _BOOL, "name": "event_dinner", "description": "Select Event Dinner", "required": False},
+                    {"type": _BOOL, "name": "optional_dinner", "description": "Select Optional Dinner", "required": False},
                 ],
             },
             # /meal event date [action]  (Admin)

--- a/Task-2/register_commands.py
+++ b/Task-2/register_commands.py
@@ -133,20 +133,47 @@ COMMANDS = [
             },
         ],
     },
-    # /location <date> <location>
+    # /location set <date> <location>
+    # /location override <user> <date> <location>  (Admin)
     {
         "name": "location",
-        "description": "Set your work location for a date (WFH automatically opts you out of all meals)",
+        "description": "Manage work location",
         "options": [
-            {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True},
             {
-                "type": _STR,
-                "name": "location",
-                "description": "OFFICE or WFH",
-                "required": True,
-                "choices": [
-                    {"name": "Office", "value": "OFFICE"},
-                    {"name": "WFH", "value": "WFH"},
+                "type": 1,
+                "name": "set",
+                "description": "Set your work location for a date (WFH automatically opts you out of all meals)",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True},
+                    {
+                        "type": _STR,
+                        "name": "location",
+                        "description": "OFFICE or WFH",
+                        "required": True,
+                        "choices": [
+                            {"name": "Office", "value": "OFFICE"},
+                            {"name": "WFH", "value": "WFH"},
+                        ],
+                    },
+                ],
+            },
+            {
+                "type": 1,
+                "name": "override",
+                "description": "[Admin] Override any user's work location",
+                "options": [
+                    {"type": _USER, "name": "user", "description": "Target user", "required": True},
+                    {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True},
+                    {
+                        "type": _STR,
+                        "name": "location",
+                        "description": "OFFICE or WFH",
+                        "required": True,
+                        "choices": [
+                            {"name": "Office", "value": "OFFICE"},
+                            {"name": "WFH", "value": "WFH"},
+                        ],
+                    },
                 ],
             },
         ],

--- a/Task-2/register_commands.py
+++ b/Task-2/register_commands.py
@@ -69,25 +69,6 @@ COMMANDS = [
                     },
                 ],
             },
-            # /meal location date location
-            {
-                "type": 1,
-                "name": "location",
-                "description": "Set your work location for a date",
-                "options": [
-                    {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True},
-                    {
-                        "type": _STR,
-                        "name": "location",
-                        "description": "OFFICE or WFH",
-                        "required": True,
-                        "choices": [
-                            {"name": "Office", "value": "OFFICE"},
-                            {"name": "WFH", "value": "WFH"},
-                        ],
-                    },
-                ],
-            },
             # /meal optout date
             {
                 "type": 1,
@@ -163,6 +144,23 @@ COMMANDS = [
                         "required": False,
                         "choices": [{"name": "Announce", "value": "announce"}],
                     },
+                ],
+            },
+        ],
+    },
+    {
+        "name": "location",
+        "description": "Set your work location for a date (WFH automatically opts you out of all meals)",
+        "options": [
+            {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True},
+            {
+                "type": _STR,
+                "name": "location",
+                "description": "OFFICE or WFH",
+                "required": True,
+                "choices": [
+                    {"name": "Office", "value": "OFFICE"},
+                    {"name": "WFH", "value": "WFH"},
                 ],
             },
         ],

--- a/Task-2/register_commands.py
+++ b/Task-2/register_commands.py
@@ -134,6 +134,19 @@ COMMANDS = [
                             {"name": "WFH", "value": "WFH"},
                         ],
                     },
+                    {
+                        "type": _STR,
+                        "name": "meal_type",
+                        "description": "Meal type",
+                        "required": False,
+                        "choices": [
+                            {"name": "Lunch", "value": "LUNCH"},
+                            {"name": "Snacks", "value": "SNACKS"},
+                            {"name": "Iftar", "value": "IFTAR"},
+                            {"name": "Event Dinner", "value": "EVENT_DINNER"},
+                            {"name": "Optional Dinner", "value": "OPTIONAL_DINNER"},
+                        ],
+                    },
                 ],
             },
             # /meal event date [action]  (Admin)

--- a/Task-2/register_commands.py
+++ b/Task-2/register_commands.py
@@ -89,7 +89,7 @@ COMMANDS = [
                     {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True}
                 ],
             },
-            # /meal override user date [opt_in] [location]  (Admin)
+            # /meal override user date [opt_in]  (Admin)
             {
                 "type": 1,
                 "name": "override",
@@ -98,16 +98,6 @@ COMMANDS = [
                     {"type": _USER, "name": "user", "description": "Target user", "required": True},
                     {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True},
                     {"type": _BOOL, "name": "opt_in", "description": "Opt in (true) or out (false)", "required": False},
-                    {
-                        "type": _STR,
-                        "name": "location",
-                        "description": "OFFICE or WFH",
-                        "required": False,
-                        "choices": [
-                            {"name": "Office", "value": "OFFICE"},
-                            {"name": "WFH", "value": "WFH"},
-                        ],
-                    },
                     {"type": _BOOL, "name": "lunch", "description": "Select Lunch", "required": False},
                     {"type": _BOOL, "name": "snacks", "description": "Select Snacks", "required": False},
                     {"type": _BOOL, "name": "iftar", "description": "Select Iftar", "required": False},

--- a/Task-2/register_commands.py
+++ b/Task-2/register_commands.py
@@ -148,6 +148,7 @@ COMMANDS = [
             },
         ],
     },
+    # /location <date> <location>
     {
         "name": "location",
         "description": "Set your work location for a date (WFH automatically opts you out of all meals)",
@@ -163,6 +164,14 @@ COMMANDS = [
                     {"name": "WFH", "value": "WFH"},
                 ],
             },
+        ],
+    },
+    # /history <user>  (Team Lead / Admin)
+    {
+        "name": "history",
+        "description": "View a user's meal and location history",
+        "options": [
+            {"type": _USER, "name": "user", "description": "Target user", "required": True},
         ],
     },
     {


### PR DESCRIPTION
<!-- Link to the issue this PR addresses -->
Closes #64 

## Dependencies

<!--  List any PRs that must be merged before this one -->
#61 

## What does this PR do?

Deploys the CraftsMeal Discord bot to AWS using a two-Lambda serverless architecture. Splits the monolithic handler into a Router Lambda (signature verification + dispatch) and a Command Lambda (business logic), migrates DynamoDB to a single-table design, and adds SnapStart support to eliminate cold starts.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation

## What was changed

**Two-Lambda split (`app/router.py` + `app/handler.py`)**
- `app/router.py` — new Router Lambda entry point. Verifies Ed25519 signature, handles Discord PING, enforces guild authorization, responds immediately with a deferred ephemeral message (type 5), then async-invokes the Command Lambda via `InvocationType="Event"`.
- `app/handler.py` — refactored into the Command Lambda. Removed all routing/auth logic. Receives the raw interaction payload directly from the Router Lambda and sends the result via `discord_service.send_followup()`.

**Single-table DynamoDB design**
- All records use `trainee-2026-abdullah-MHP_Table` with composite `PK`/`SK` keys and a `GSI1` for date-based queries.
- Removed the two-table write-through pattern.

**SnapStart readiness**
- All boto3 clients, settings, and event config are initialized at module level so they are captured in the Lambda snapshot and skipped on restore.

**Build script (`build.sh`)**
- Added `--platform manylinux2014_aarch64` and `--only-binary=:all:` flags to install Linux arm64 compatible wheels on Windows, fixing `pydantic_core` and `pynacl` import errors on Lambda.

**Config (`app/config.py`)**
- Added `command_lambda_name` setting for the Router to know which Lambda to invoke.
- Made `internal_api_key` optional (dashboard API out of scope for this iteration).
- Removed `AWS_REGION` from required env vars (reserved by Lambda runtime).

## Changelog

Feature: CraftsMeal Discord bot is now deployed on AWS — slash commands are handled serverlessly via API Gateway, two Lambda functions, and DynamoDB.

## How to Test

1. Run `bash build.sh` to produce `lambda.zip` with Linux arm64 wheels
2. Upload `lambda.zip` to both `trainee-2026-abdullah-craftsmeal-router` and `trainee-2026-abdullah-craftsmeal-command` in AWS Lambda
3. Publish a new version on each Lambda and confirm SnapStart status is **Ready**
4. Set the API Gateway invoke URL as the Discord Interactions Endpoint URL — Discord should show ✅
5. Run `python register_commands.py` to register slash commands
6. In Discord, run `/meal status` — bot should reply with today's opt-in status

## How QA Should Test

**Affected workflows:**
- All `/meal` subcommands (status, update, location, opt-out, summary, summary-all, override, event)
- `/special-day` subcommand (view)

**Specific checks:**
1. Send `/meal status` — verify ephemeral reply with correct opt-in status for today
2. Send `/meal update date:<today> opt_in:True` — verify confirmation reply
3. Send `/meal status` again — verify status reflects the update
4. Send `/meal summary date:<today>` as Team Lead — verify headcount summary is returned
5. Send `/meal summary-all date:<today>` as Admin — verify full team breakdown
6. Trigger an unknown subcommand — verify graceful error reply
7. Check CloudWatch logs for both Lambdas — verify no errors and Router dispatch logs appear

## Rollback Plan

- Revert this PR and redeploy the previous `lambda.zip` to both Lambda functions
- Re-point API Gateway integration to the previous published version ARN

## Checklist

- [x] My code follows the project style guidelines
- [ ] Code passes linting and type checks
- [ ] All tests pass
- [ ] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)

## Test Environment

| Component | Value |
|---|---|
| AWS Region | `ap-southeast-1` |
| Router Lambda | `trainee-2026-abdullah-craftsmeal-router` |
| Command Lambda | `trainee-2026-abdullah-craftsmeal-command` |
| DynamoDB Table | `trainee-2026-abdullah-MHP_Table` |
| API Gateway | `trainee-2026-abdullah-craftsmeal-api` |
| Runtime | Python 3.12 / arm64 |
| Discord Guild | MHP-test `1479421411763421366` |
| Interactions URL | `https://37mup49l17.execute-api.ap-southeast-1.amazonaws.com/interactions` |

## Screenshots (if applicable)

<!-- Add screenshots for UI changes -->

## Note for Reviewer

- The Router Lambda must use the **published version ARN** (not `$LATEST`) in API Gateway for SnapStart to work
- The IAM role `trainee-2026-abdullah-mhp-lambda-role` must have `lambda:InvokeFunction` on `trainee-2026-abdullah-craftsmeal-command` — without this the Router silently fails to dispatch commands
- `AWS_REGION` must **not** be set as a Lambda environment variable — it is reserved by the runtime
