### PR TITLE
[PR-12] feat: add GChat Router Lambda with JWT auth, identity resolution & BotContext (issue 2.14)

### DIFF
--- a/Task-2/app/config.py
+++ b/Task-2/app/config.py
@@ -30,6 +30,10 @@ class Settings(BaseSettings):
     # Announcement channel (optional — used by /event announce)
     announcement_channel_id: str = ""
 
+    # Google Chat
+    gchat_audience: str = ""
+    gchat_authorized_space: str = ""
+    gchat_announcement_space: str = ""
 
 
-settings = Settings()  
+settings = Settings()

--- a/Task-2/app/gchat_router.py
+++ b/Task-2/app/gchat_router.py
@@ -1,0 +1,276 @@
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import logging
+import uuid
+from dataclasses import asdict
+from typing import Any
+
+import boto3
+from google.auth.transport import requests as google_requests
+from google.oauth2 import id_token
+
+from app.config import settings
+from app.models.gchat_models import GChatEvent
+from app.platform.bot_context import BotContext
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+
+_lambda_client = boto3.client("lambda", region_name=settings.aws_region)
+_dynamodb = boto3.resource("dynamodb", region_name=settings.aws_region)
+_table = _dynamodb.Table(settings.dynamodb_table)
+
+_EXPECTED_ISSUER = "chat@system.gserviceaccount.com"
+
+# Google Chat commandId → MHP command name (must match Cloud Console registration)
+_COMMAND_MAP: dict[str, str] = {
+    "1": "meal",
+    "2": "location",
+    "3": "headcount",
+    "4": "team-members",
+    "5": "wfh-periods",
+    "6": "event",
+    "7": "meal-type",
+}
+
+# Commands that use subcommands as the first positional argument
+_SUBCOMMAND_COMMANDS = {"meal", "location", "wfh-periods", "event", "meal-type"}
+
+# Positional parameter names for each (command, subcommand) pair
+_PARAM_SCHEMAS: dict[tuple[str, str | None], list[str]] = {
+    ("meal", "status"):    ["user", "date"],
+    ("meal", "set"):       ["date", "opt_in", "meal_types", "user"],
+    ("meal", "bulk"):      ["start_date", "end_date", "opt_in", "user"],
+    ("location", "status"):["user", "date"],
+    ("location", "set"):   ["date", "location", "user"],
+    ("location", "bulk"):  ["start_date", "end_date", "location", "user"],
+    ("headcount", None):   ["date", "user"],
+    ("team-members", None):["team_id"],
+    ("wfh-periods", "set"):    ["start_date", "end_date"],
+    ("wfh-periods", "delete"): ["start_date", "end_date"],
+    ("wfh-periods", "list"):   [],
+    ("event", "announce"): ["date"],
+    ("event", "optout"):   ["date"],
+    ("event", "list"):     [],
+    ("event", "update"):   ["date", "description"],
+    ("event", "delete"):   ["date"],
+    ("meal-type", "activate"):   ["date", "meal_type"],
+    ("meal-type", "deactivate"): ["date", "meal_type"],
+    ("meal-type", "list"):       ["date"],
+}
+
+_BOOL_STRINGS = {"true": True, "false": False, "yes": True, "no": False, "1": True, "0": False}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _ok(body: dict) -> dict:
+    return {"statusCode": 200, "headers": {"Content-Type": "application/json"}, "body": json.dumps(body)}
+
+
+def _err(status: int, message: str) -> dict:
+    return {"statusCode": status, "headers": {"Content-Type": "application/json"}, "body": json.dumps({"error": message})}
+
+
+# ---------------------------------------------------------------------------
+# JWT Verification
+# ---------------------------------------------------------------------------
+
+def _verify_jwt(headers: dict) -> bool:
+    """Verify the Google-issued JWT bearer token (§3.1.2)."""
+    auth_header = headers.get("authorization", "")
+    if not auth_header.lower().startswith("bearer "):
+        return False
+
+    token = auth_header[len("bearer "):].strip()
+    if not token:
+        return False
+
+    try:
+        claims = id_token.verify_oauth2_token(
+            token,
+            google_requests.Request(),
+            audience=settings.gchat_audience,
+        )
+    except Exception as exc:
+        logger.warning("JWT verification failed: %s", exc)
+        return False
+
+    if claims.get("iss") != _EXPECTED_ISSUER:
+        logger.warning("JWT issuer mismatch: got %s", claims.get("iss"))
+        return False
+
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Identity Resolution & Auto-Registration (§3.4)
+# ---------------------------------------------------------------------------
+
+def _resolve_or_register_user(google_user_id: str, email: str) -> tuple[str, str]:
+    """Resolve internal userId and role from DynamoDB, or auto-register.
+
+    Returns (user_id, role).
+    """
+    ext_key = f"EXTID#GCHAT#{google_user_id}"
+
+    # Look up existing identity mapping
+    resp = _table.get_item(Key={"PK": ext_key, "SK": ext_key})
+    item = resp.get("Item")
+
+    if item:
+        user_id = item["user_id"]
+    else:
+        # Auto-register: create identity mapping + user metadata
+        user_id = str(uuid.uuid4())
+        _table.put_item(Item={
+            "PK": ext_key,
+            "SK": ext_key,
+            "user_id": user_id,
+            "email": email,
+        })
+        _table.put_item(Item={
+            "PK": f"USER#{user_id}",
+            "SK": "METADATA",
+            "GSI1PK": "USERS",
+            "GSI1SK": f"USER#{user_id}",
+            "user_id": user_id,
+            "email": email,
+            "role": "EMPLOYEE",
+            "platform": "gchat",
+        })
+        logger.info("Auto-registered GChat user %s as %s", google_user_id, user_id)
+
+    # Fetch role from user metadata
+    user_resp = _table.get_item(Key={"PK": f"USER#{user_id}", "SK": "METADATA"})
+    user_item = user_resp.get("Item", {})
+    role = user_item.get("role", "EMPLOYEE")
+
+    return user_id, role
+
+
+# ---------------------------------------------------------------------------
+# Argument Parsing
+# ---------------------------------------------------------------------------
+
+def _coerce_value(name: str, raw: str) -> Any:
+    """Coerce a raw string argument to the appropriate Python type."""
+    if name == "opt_in":
+        return _BOOL_STRINGS.get(raw.lower(), raw)
+    if name == "meal_types":
+        return [mt.strip().upper() for mt in raw.split(",") if mt.strip()]
+    return raw
+
+
+def _parse_arguments(command: str, argument_text: str) -> tuple[str | None, dict[str, Any]]:
+    """Parse Google Chat argumentText into (subcommand, options dict)."""
+    tokens = argument_text.strip().split() if argument_text.strip() else []
+
+    subcommand: str | None = None
+    if command in _SUBCOMMAND_COMMANDS:
+        if tokens:
+            subcommand = tokens.pop(0).lower()
+        else:
+            return None, {}
+
+    schema = _PARAM_SCHEMAS.get((command, subcommand), [])
+    options: dict[str, Any] = {}
+
+    # Special case: "description" consumes all remaining tokens
+    for i, param_name in enumerate(schema):
+        if i >= len(tokens):
+            break
+        if param_name == "description":
+            options[param_name] = " ".join(tokens[i:])
+            break
+        options[param_name] = _coerce_value(param_name, tokens[i])
+
+    return subcommand, options
+
+
+# ---------------------------------------------------------------------------
+# Lambda Handler
+# ---------------------------------------------------------------------------
+
+def handler(event: dict, context: Any) -> dict:
+    method = event.get("requestContext", {}).get("http", {}).get("method", "")
+    path = event.get("rawPath", "")
+
+    if method != "POST" or path != "/gchat/interactions":
+        return _err(404, "Not found")
+
+    # --- Decode body ---
+    body_str: str = event.get("body", "") or ""
+    try:
+        raw_body = base64.b64decode(body_str) if event.get("isBase64Encoded") else body_str.encode()
+    except binascii.Error:
+        return _err(400, "Invalid request body")
+
+    headers = {k.lower(): v for k, v in (event.get("headers") or {}).items()}
+
+    # --- JWT verification (§3.1.2) ---
+    if not _verify_jwt(headers):
+        logger.warning("Invalid or missing JWT")
+        return _err(401, "Invalid request signature")
+
+    # --- Parse payload ---
+    try:
+        payload = json.loads(raw_body)
+    except json.JSONDecodeError:
+        return _err(400, "Invalid request body")
+
+    gchat_event = GChatEvent(**payload)
+
+    # --- Space authorization guard (§3.4) ---
+    if gchat_event.get_space_name() != settings.gchat_authorized_space:
+        logger.warning("Unauthorized space: %s", gchat_event.get_space_name())
+        return _err(401, "Unauthorized space")
+
+    # --- Identity resolution ---
+    sender = gchat_event.get_sender()
+    google_user_id = sender.get_google_user_id()
+    if not google_user_id:
+        return _err(400, "Unable to identify sender")
+
+    user_id, role = _resolve_or_register_user(google_user_id, sender.email)
+
+    # --- Parse command ---
+    slash_cmd = gchat_event.message.slashCommand
+    if not slash_cmd or not slash_cmd.commandId:
+        return _err(400, "No slash command in payload")
+
+    command = _COMMAND_MAP.get(slash_cmd.commandId)
+    if not command:
+        return _err(400, f"Unknown command ID: {slash_cmd.commandId}")
+
+    subcommand, options = _parse_arguments(command, gchat_event.message.argumentText)
+
+    # --- Build BotContext ---
+    bot_ctx = BotContext(
+        user_id=user_id,
+        role=role,
+        platform="gchat",
+        command=command,
+        subcommand=subcommand,
+        options=options,
+        space=gchat_event.get_space_name(),
+    )
+
+    # --- Async dispatch to Command Lambda ---
+    try:
+        _lambda_client.invoke(
+            FunctionName=settings.command_lambda_name,
+            InvocationType="Event",
+            Payload=json.dumps(asdict(bot_ctx)).encode(),
+        )
+        logger.info("Dispatched command=%s subcommand=%s to %s", command, subcommand, settings.command_lambda_name)
+    except Exception as exc:
+        logger.error("Failed to invoke command lambda: %s", exc)
+
+    # --- Immediate ACK ---
+    return _ok({})

--- a/Task-2/app/models/gchat_models.py
+++ b/Task-2/app/models/gchat_models.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class GChatSender(BaseModel):
+    name: str = ""
+    displayName: str = ""
+    email: str = ""
+    type: str = "HUMAN"
+
+    def get_google_user_id(self) -> str:
+        """Extract the Google user ID from 'users/<googleUserId>'."""
+        if self.name.startswith("users/"):
+            return self.name[len("users/"):]
+        return self.name
+
+
+class GChatSpace(BaseModel):
+    name: str = ""
+    type: str = ""
+    displayName: str = ""
+
+
+class GChatSlashCommand(BaseModel):
+    commandId: str = ""
+
+
+class GChatMessage(BaseModel):
+    name: str = ""
+    sender: GChatSender = GChatSender()
+    text: str = ""
+    argumentText: str = ""
+    slashCommand: GChatSlashCommand | None = None
+
+
+class GChatEvent(BaseModel):
+    type: str = ""
+    eventTime: str = ""
+    space: GChatSpace = GChatSpace()
+    message: GChatMessage = GChatMessage()
+    user: GChatSender = GChatSender()
+
+    def get_sender(self) -> GChatSender:
+        """Return the sender from the message payload, falling back to top-level user."""
+        if self.message.sender.name:
+            return self.message.sender
+        return self.user
+
+    def get_space_name(self) -> str:
+        return self.space.name

--- a/Task-2/app/platform/bot_context.py
+++ b/Task-2/app/platform/bot_context.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+
+@dataclass
+class BotContext:
+    """Platform-neutral context produced by both the Discord and GChat routers.
+
+    The shared Command Lambda handler consumes this instead of
+    platform-specific interaction payloads.
+    """
+
+    # Identity
+    user_id: str
+    role: Literal["EMPLOYEE", "TEAM_LEAD", "ADMIN"] = "EMPLOYEE"
+    platform: Literal["discord", "gchat"] = "discord"
+
+    # Command
+    command: str = ""
+    subcommand: str | None = None
+    options: dict[str, Any] = field(default_factory=dict)
+
+    # Platform-specific delivery context
+    # Discord: interaction token for follow-up webhook
+    # GChat: space resource name for reply
+    token: str = ""
+    space: str = ""
+
+    # Discord-specific (kept for backward compat during migration)
+    discord_roles: list[str] = field(default_factory=list)
+    discord_application_id: str = ""

--- a/Task-2/requirements.txt
+++ b/Task-2/requirements.txt
@@ -2,5 +2,6 @@ boto3
 pydantic
 pydantic-settings
 pynacl
+google-auth
 python-dotenv
 tzdata


### PR DESCRIPTION
Closes #72 

## Dependencies

- _(none needed)_

## What does this PR do?

Adds the Google Chat Router Lambda — the ingress entry point that authenticates incoming Google Chat events via JWT, resolves user identity from DynamoDB, and dispatches commands to the shared Command Lambda using a platform-neutral `BotContext`.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Documentation

## What was changed

### 1. Config & Dependencies
- Added `google-auth` to `requirements.txt` for JWT verification.
- Added three GChat env vars to `app/config.py`: `gchat_audience`, `gchat_authorized_space`, `gchat_announcement_space`.

### 2. GChat Payload Models (`app/models/gchat_models.py`)
- Pydantic models mirroring the Google Chat event payload: `GChatEvent`, `GChatMessage`, `GChatSender`, `GChatSpace`, `GChatSlashCommand`.
- `GChatSender.get_google_user_id()` extracts the ID from the `users/<googleUserId>` format.

### 3. Platform-Neutral BotContext (`app/platform/bot_context.py`)
- Dataclass carrying `user_id`, `role`, `platform`, `command`, `subcommand`, `options`, and platform-specific delivery context (`token` for Discord, `space` for GChat).
- Both routers will normalize their payloads into this before invoking the Command Lambda.

### 4. GChat Router Lambda (`app/gchat_router.py`)
- **JWT verification:** Validates the `Authorization: Bearer <token>` header using `google.oauth2.id_token.verify_oauth2_token`. Checks `iss == chat@system.gserviceaccount.com` and `aud == GCHAT_AUDIENCE`.
- **Space authorization guard:** Rejects requests where `space.name` does not match `GCHAT_AUTHORIZED_SPACE`.
- **Identity resolution & auto-registration:** Looks up `EXTID#GCHAT#<googleUserId>` in DynamoDB. If not found, creates both the identity mapping and a `USER#<userId>/METADATA` item with `role=EMPLOYEE` and a generated UUID as the internal userId.
- **DynamoDB role resolution:** Reads the `role` attribute from the user's metadata item; defaults to `EMPLOYEE`.
- **Argument parsing:** Table-driven parser maps `commandId` → command name, splits `argumentText` into positional params per command schema, and coerces types (booleans, comma-separated meal types).
- **Async dispatch:** Serializes the `BotContext` as JSON and async-invokes the shared Command Lambda.

### Design decisions
- **UUID for internal userId:** GChat users get a UUID-based internal userId (unlike Discord which uses the snowflake directly). This keeps the `EXTID` pattern clean and allows future cross-platform identity linking.
- **Table-driven argument parsing:** Each `(command, subcommand)` pair has a positional parameter schema. This is explicit, easy to extend, and avoids complex natural language parsing.
- **BotContext not yet consumed by handler:** The shared `handler.py` still expects `DiscordInteraction` payloads. Wiring the handler to accept `BotContext` is scoped to Issue 2.

## Changelog

Feature: Google Chat Router Lambda with JWT authentication, identity auto-registration, and command dispatch

## How to Test

1. Deploy the GChat Router Lambda to AWS with the three new env vars configured (`GCHAT_AUDIENCE`, `GCHAT_AUTHORIZED_SPACE`, `GCHAT_ANNOUNCEMENT_SPACE`).
2. Configure a Google Chat app in the Cloud Console pointing to `POST /gchat/interactions`.
3. Send a slash command from the authorized Google Chat space — verify the router returns `HTTP 200` and the Command Lambda is invoked.
4. Check DynamoDB for the auto-registered `EXTID#GCHAT#<googleUserId>` and `USER#<userId>/METADATA` items on first interaction.
5. Send a request from an unauthorized space — verify `HTTP 401` is returned.
6. Send a request with an invalid/missing JWT — verify `HTTP 401` is returned.

## How QA Should Test

Affected workflows:
- Google Chat slash command ingress (new)
- Existing Discord flow is unaffected (no changes to `router.py` or `handler.py`)

Specific checks:
- Verify JWT rejection: tamper with the Authorization header and confirm `401`.
- Verify space guard: send a request with a different `space.name` and confirm `401`.
- Verify auto-registration: use a new Google Chat user, confirm both DynamoDB items are created with `role=EMPLOYEE`.
- Verify role resolution: manually set a user's role to `ADMIN` in DynamoDB, send a command, and confirm the `BotContext` carries `role=ADMIN`.
- Verify argument parsing: test commands with varying numbers of positional args (e.g., `/meal set 2026-04-01 true`, `/event list` with no args).

## Rollback Plan

- Revert this PR. The GChat Router Lambda is a new, independent function — removing it has zero impact on the existing Discord flow.

## Checklist

- [x] My code follows the project style guidelines
- [ ] Code passes linting and type checks
- [ ] All tests pass
- [ ] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)

## Screenshots (if applicable)

N/A — backend-only change, no UI.

## Note for Reviewer

- The `BotContext` dataclass includes `discord_roles` and `discord_application_id` fields for backward compatibility during the migration. These will be used when the Discord router is refactored to also produce a `BotContext` (Issue 2).
- The `_COMMAND_MAP` commandId values (`"1"` through `"7"`) must match the slash command IDs configured in the Google Cloud Console. These are set during app registration.
- Automated tests are out of scope for this iteration (see tech spec §6).