### PR TITLE
[PR-13] feat: add GChat response service, platform-agnostic handler & command registration (issue 2.15)

### DIFF
--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -43,7 +43,7 @@ def _discord_to_bot_context(interaction: DiscordInteraction) -> BotContext:
         raw_options = list(interaction.data.options)
         if raw_options and raw_options[0].type == 1:
             subcommand = raw_options[0].name
-            raw_options = list(raw_options[0].options)
+            raw_options = list(raw_options[0].options or [])
         options = {opt.name: opt.value for opt in raw_options}
 
     return BotContext(

--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -1,50 +1,155 @@
 from __future__ import annotations
 
 import logging
-from datetime import date as _date
+from datetime import date as _date, timedelta
 from typing import Any
+
+import boto3
+from boto3.dynamodb.conditions import Attr, Key
 
 from app.config import settings
 from app.models.discord_models import DiscordInteraction
 from app.models.meal_models import MealRecord
-from app.services import discord_service, headcount_service, meal_service, team_service
+from app.platform.bot_context import BotContext
+from app.services import discord_service, gchat_service, headcount_service, meal_service, team_service
 
 logger = logging.getLogger(__name__)
 logger.setLevel(logging.INFO)
+
+_dynamodb = boto3.resource("dynamodb", region_name=settings.aws_region)
+_table = _dynamodb.Table(settings.dynamodb_table)
+
+
+# ---------------------------------------------------------------------------
+# Platform Detection & BotContext Construction
+# ---------------------------------------------------------------------------
+
+def _discord_to_bot_context(interaction: DiscordInteraction) -> BotContext:
+    """Convert a DiscordInteraction into a platform-neutral BotContext."""
+    roles = interaction.get_roles()
+    if settings.role_admin_id in roles:
+        role = "ADMIN"
+    elif settings.role_team_lead_id in roles:
+        role = "TEAM_LEAD"
+    else:
+        role = "EMPLOYEE"
+
+    command = ""
+    subcommand = None
+    options: dict[str, Any] = {}
+
+    if interaction.data:
+        command = interaction.data.name
+        raw_options = list(interaction.data.options)
+        if raw_options and raw_options[0].type == 1:
+            subcommand = raw_options[0].name
+            raw_options = list(raw_options[0].options)
+        options = {opt.name: opt.value for opt in raw_options}
+
+    return BotContext(
+        user_id=interaction.get_user().id,
+        role=role,
+        platform="discord",
+        command=command,
+        subcommand=subcommand,
+        options=options,
+        token=interaction.token,
+        discord_roles=roles,
+        discord_application_id=interaction.application_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Role Checks
+# ---------------------------------------------------------------------------
+
+def _is_admin(ctx: BotContext) -> bool:
+    return ctx.role == "ADMIN"
+
+
+def _is_team_lead(ctx: BotContext) -> bool:
+    return ctx.role in ("TEAM_LEAD", "ADMIN")
+
+
+# ---------------------------------------------------------------------------
+# User Helpers
+# ---------------------------------------------------------------------------
+
+def _user_label(ctx: BotContext, user_id: str) -> str:
+    """Format a user reference appropriate for the platform."""
+    if ctx.platform == "discord":
+        return f"<@{user_id}>"
+    return user_id
+
+
+def _resolve_user_param(ctx: BotContext, identifier: str) -> str | None:
+    """Resolve a user parameter to an internal userId.
+
+    Discord: the identifier IS the internal userId (snowflake).
+    GChat: resolve Google user ID or email → internal userId via DynamoDB.
+    """
+    if ctx.platform == "discord":
+        return identifier
+
+    # Try EXTID lookup by Google user ID
+    ext_key = f"EXTID#GCHAT#{identifier}"
+    resp = _table.get_item(Key={"PK": ext_key, "SK": ext_key})
+    item = resp.get("Item")
+    if item:
+        return item["user_id"]
+
+    # Try email lookup via GSI1 (all users)
+    resp = _table.query(
+        IndexName="GSI1",
+        KeyConditionExpression=Key("GSI1PK").eq("USERS"),
+        FilterExpression=Attr("email").eq(identifier),
+    )
+    items = resp.get("Items", [])
+    if items:
+        return items[0]["user_id"]
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Option Helpers
+# ---------------------------------------------------------------------------
+
+def _collect_meal_types(ctx: BotContext) -> list[str] | None:
+    """Collect meal types from options. Returns None if none selected (means all)."""
+    # GChat: pre-parsed list
+    mt = ctx.options.get("meal_types")
+    if mt and isinstance(mt, list):
+        return mt
+    # Discord: individual boolean options
+    selected = [
+        name.upper()
+        for name in ("lunch", "snacks", "iftar", "event_dinner", "optional_dinner")
+        if ctx.options.get(name)
+    ]
+    return selected or None
 
 
 def _reply(content: str, ephemeral: bool = True) -> tuple[str, bool]:
     return content, ephemeral
 
 
-def _has_role(interaction: DiscordInteraction, role_id: str) -> bool:
-    return role_id in interaction.get_roles()
+# ---------------------------------------------------------------------------
+# Command Handlers (all take BotContext)
+# ---------------------------------------------------------------------------
 
-
-def _is_admin(interaction: DiscordInteraction) -> bool:
-    return _has_role(interaction, settings.role_admin_id)
-
-
-def _is_team_lead(interaction: DiscordInteraction) -> bool:
-    return _has_role(interaction, settings.role_team_lead_id) or _is_admin(interaction)
-
-
-def _get_option(options: list, name: str) -> Any:
-    for opt in options:
-        if opt.name == name:
-            return opt.value
-    return None
-
-
-def _handle_meal_status(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
-    user_id = interaction.get_user().id
-    target_user = _get_option(options, "user")
-    if target_user and target_user != user_id:
-        if not _is_team_lead(interaction):
+def _handle_meal_status(ctx: BotContext) -> tuple[str, bool]:
+    target_user = ctx.options.get("user")
+    if target_user:
+        resolved = _resolve_user_param(ctx, target_user)
+        if not resolved:
+            return _reply(f"User not found: {target_user}")
+        target_user = resolved
+        if target_user != ctx.user_id and not _is_team_lead(ctx):
             return _reply("You do not have permission to view another user's meal status.")
     else:
-        target_user = user_id
-    target_date = _get_option(options, "date") or str(_date.today())
+        target_user = ctx.user_id
+    target_date = ctx.options.get("date") or str(_date.today())
     record = meal_service.get_record(target_date, target_user) or MealRecord(date=target_date, user_id=target_user)
     if not record.meal_opt_in:
         status = "opted out (all meals)"
@@ -52,105 +157,117 @@ def _handle_meal_status(interaction: DiscordInteraction, options: list) -> tuple
         status = f"opted out of: {', '.join(record.opted_out_meals)}"
     else:
         status = "opted in (all meals)"
-    label = f"<@{target_user}>" if target_user != user_id else "You"
+    label = _user_label(ctx, target_user) if target_user != ctx.user_id else "You"
     return _reply(f"**{target_date}** — {label}: {status} | Location: {record.work_location}")
 
 
-def _collect_meal_types(options: list) -> list[str] | None:
-    """Collect selected meal type booleans. Returns None if none selected (means all)."""
-    selected = [mt.upper() for mt in ("lunch", "snacks", "iftar", "event_dinner", "optional_dinner") if _get_option(options, mt)]
-    return selected or None
-
-
-def _handle_meal_set(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
-    user_id = interaction.get_user().id
-    target_date = _get_option(options, "date")
+def _handle_meal_set(ctx: BotContext) -> tuple[str, bool]:
+    target_date = ctx.options.get("date")
     if not target_date:
         return _reply("Please provide a date.")
-    target_user = _get_option(options, "user")
+    target_user = ctx.options.get("user")
     bypass = False
-    if target_user and target_user != user_id:
-        if not _is_team_lead(interaction):
-            return _reply("You do not have permission to update another user's meal record.")
-        bypass = True
+    if target_user:
+        resolved = _resolve_user_param(ctx, target_user)
+        if not resolved:
+            return _reply(f"User not found: {target_user}")
+        target_user = resolved
+        if target_user != ctx.user_id:
+            if not _is_team_lead(ctx):
+                return _reply("You do not have permission to update another user's meal record.")
+            bypass = True
     else:
-        target_user = user_id
-    opt_in_val = _get_option(options, "opt_in")
-    meal_types = _collect_meal_types(options)
+        target_user = ctx.user_id
+    opt_in_val = ctx.options.get("opt_in")
+    meal_types = _collect_meal_types(ctx)
     if opt_in_val is not None:
         fn = meal_service.opt_in if opt_in_val else meal_service.opt_out
-        return _reply(fn(target_date, target_user, updated_by=user_id, meal_types=meal_types, bypass_cutoff=bypass))
+        return _reply(fn(target_date, target_user, updated_by=ctx.user_id, meal_types=meal_types, bypass_cutoff=bypass))
     if meal_types:
-        return _reply(meal_service.opt_out(target_date, target_user, updated_by=user_id, meal_types=meal_types, bypass_cutoff=bypass))
+        return _reply(meal_service.opt_out(target_date, target_user, updated_by=ctx.user_id, meal_types=meal_types, bypass_cutoff=bypass))
     return _reply("Nothing to update.")
 
 
-
-def _handle_meal_bulk(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
-    user_id = interaction.get_user().id
-    start_date = _get_option(options, "start_date")
-    end_date = _get_option(options, "end_date")
-    opt_in_val = _get_option(options, "opt_in")
+def _handle_meal_bulk(ctx: BotContext) -> tuple[str, bool]:
+    start_date = ctx.options.get("start_date")
+    end_date = ctx.options.get("end_date")
+    opt_in_val = ctx.options.get("opt_in")
     if not start_date or not end_date or opt_in_val is None:
         return _reply("Please provide start_date, end_date, and opt_in.")
-    target_user = _get_option(options, "user")
+    target_user = ctx.options.get("user")
     bypass = False
-    if target_user and target_user != user_id:
-        if not _is_team_lead(interaction):
-            return _reply("You do not have permission to bulk-update another user's meal records.")
-        bypass = True
+    if target_user:
+        resolved = _resolve_user_param(ctx, target_user)
+        if not resolved:
+            return _reply(f"User not found: {target_user}")
+        target_user = resolved
+        if target_user != ctx.user_id:
+            if not _is_team_lead(ctx):
+                return _reply("You do not have permission to bulk-update another user's meal records.")
+            bypass = True
     else:
-        target_user = user_id
-    return _reply(meal_service.bulk_meal_update(start_date, end_date, opt_in_val, target_user, updated_by=user_id, bypass_cutoff=bypass))
+        target_user = ctx.user_id
+    return _reply(meal_service.bulk_meal_update(start_date, end_date, opt_in_val, target_user, updated_by=ctx.user_id, bypass_cutoff=bypass))
 
 
-def _handle_location_status(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
-    user_id = interaction.get_user().id
-    target_user = _get_option(options, "user")
-    if target_user and target_user != user_id:
-        if not _is_team_lead(interaction):
+def _handle_location_status(ctx: BotContext) -> tuple[str, bool]:
+    target_user = ctx.options.get("user")
+    if target_user:
+        resolved = _resolve_user_param(ctx, target_user)
+        if not resolved:
+            return _reply(f"User not found: {target_user}")
+        target_user = resolved
+        if target_user != ctx.user_id and not _is_team_lead(ctx):
             return _reply("You do not have permission to view another user's location.")
     else:
-        target_user = user_id
-    target_date = _get_option(options, "date") or str(_date.today())
+        target_user = ctx.user_id
+    target_date = ctx.options.get("date") or str(_date.today())
     record = meal_service.get_record(target_date, target_user) or MealRecord(date=target_date, user_id=target_user)
-    label = f"<@{target_user}>" if target_user != user_id else "You"
+    label = _user_label(ctx, target_user) if target_user != ctx.user_id else "You"
     return _reply(f"**{target_date}** — {label}: {record.work_location}")
 
 
-def _handle_work_location(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
-    user_id = interaction.get_user().id
-    target_date = _get_option(options, "date")
-    location = _get_option(options, "location")
+def _handle_work_location(ctx: BotContext) -> tuple[str, bool]:
+    target_date = ctx.options.get("date")
+    location = ctx.options.get("location")
     if not target_date or not location:
         return _reply("Please provide both date and location.")
-    target_user = _get_option(options, "user")
+    target_user = ctx.options.get("user")
     bypass = False
-    if target_user and target_user != user_id:
-        if not _is_team_lead(interaction):
-            return _reply("You do not have permission to update another user's location.")
-        bypass = True
+    if target_user:
+        resolved = _resolve_user_param(ctx, target_user)
+        if not resolved:
+            return _reply(f"User not found: {target_user}")
+        target_user = resolved
+        if target_user != ctx.user_id:
+            if not _is_team_lead(ctx):
+                return _reply("You do not have permission to update another user's location.")
+            bypass = True
     else:
-        target_user = user_id
-    return _reply(meal_service.update_location(target_date, target_user, location, updated_by=user_id, bypass_cutoff=bypass))
+        target_user = ctx.user_id
+    return _reply(meal_service.update_location(target_date, target_user, location, updated_by=ctx.user_id, bypass_cutoff=bypass))
 
 
-def _handle_location_bulk(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
-    user_id = interaction.get_user().id
-    start_date = _get_option(options, "start_date")
-    end_date = _get_option(options, "end_date")
-    location = _get_option(options, "location")
+def _handle_location_bulk(ctx: BotContext) -> tuple[str, bool]:
+    start_date = ctx.options.get("start_date")
+    end_date = ctx.options.get("end_date")
+    location = ctx.options.get("location")
     if not start_date or not end_date or not location:
         return _reply("Please provide start_date, end_date, and location.")
-    target_user = _get_option(options, "user")
+    target_user = ctx.options.get("user")
     bypass = False
-    if target_user and target_user != user_id:
-        if not _is_team_lead(interaction):
-            return _reply("You do not have permission to bulk-update another user's location records.")
-        bypass = True
+    if target_user:
+        resolved = _resolve_user_param(ctx, target_user)
+        if not resolved:
+            return _reply(f"User not found: {target_user}")
+        target_user = resolved
+        if target_user != ctx.user_id:
+            if not _is_team_lead(ctx):
+                return _reply("You do not have permission to bulk-update another user's location records.")
+            bypass = True
     else:
-        target_user = user_id
-    return _reply(meal_service.bulk_location_update(start_date, end_date, location, target_user, updated_by=user_id, bypass_cutoff=bypass))
+        target_user = ctx.user_id
+    return _reply(meal_service.bulk_location_update(start_date, end_date, location, target_user, updated_by=ctx.user_id, bypass_cutoff=bypass))
 
 
 _LOCATION_HANDLERS = {
@@ -159,7 +276,6 @@ _LOCATION_HANDLERS = {
     "bulk":   _handle_location_bulk,
 }
 
-
 _MEAL_HANDLERS = {
     "status": _handle_meal_status,
     "set":    _handle_meal_set,
@@ -167,11 +283,11 @@ _MEAL_HANDLERS = {
 }
 
 
-def _handle_meal(interaction: DiscordInteraction, subcommand: str, options: list) -> tuple[str, bool]:
-    handler_fn = _MEAL_HANDLERS.get(subcommand)
+def _handle_meal(ctx: BotContext) -> tuple[str, bool]:
+    handler_fn = _MEAL_HANDLERS.get(ctx.subcommand)
     if not handler_fn:
         return _reply("Unknown subcommand.")
-    return handler_fn(interaction, options)
+    return handler_fn(ctx)
 
 
 _MEAL_TYPE_LABELS = {
@@ -204,14 +320,16 @@ def _format_headcount_summary(summary: dict, title: str) -> str:
     return "\n".join(lines)
 
 
-def _handle_headcount(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
-    user_id = interaction.get_user().id
-    target_date = _get_option(options, "date")
-    target_user = _get_option(options, "user")
+def _handle_headcount(ctx: BotContext) -> tuple[str, bool]:
+    target_date = ctx.options.get("date")
+    target_user = ctx.options.get("user")
 
-    if _is_admin(interaction) or _is_team_lead(interaction):
+    if _is_admin(ctx) or _is_team_lead(ctx):
         if target_user:
-            # Show a specific user's record for the given date
+            resolved = _resolve_user_param(ctx, target_user)
+            if not resolved:
+                return _reply(f"User not found: {target_user}")
+            target_user = resolved
             if not target_date:
                 return _reply("Please provide a date when specifying a user.")
             record = meal_service.get_record(target_date, target_user) or MealRecord(date=target_date, user_id=target_user)
@@ -221,14 +339,14 @@ def _handle_headcount(interaction: DiscordInteraction, options: list) -> tuple[s
                 status = f"opted out of: {', '.join(record.opted_out_meals)}"
             else:
                 status = "opted in (all meals)"
-            return _reply(f"**{target_date}** — <@{target_user}>: {status} | Location: {record.work_location}")
+            label = _user_label(ctx, target_user)
+            return _reply(f"**{target_date}** — {label}: {status} | Location: {record.work_location}")
 
         if target_date:
-            if _is_admin(interaction):
+            if _is_admin(ctx):
                 summary = headcount_service.daily_summary(target_date)
                 return _reply(_format_headcount_summary(summary, f"Org-wide Headcount for {target_date}"))
-            # Team Lead: scope to their team
-            team = team_service.get_user_team(user_id)
+            team = team_service.get_user_team(ctx.user_id)
             if not team:
                 return _reply("You are not assigned to any team. Ask an Admin to add you to a team.")
             member_ids = team_service.get_team_members(team["team_id"])
@@ -237,11 +355,13 @@ def _handle_headcount(interaction: DiscordInteraction, options: list) -> tuple[s
         # No date and no user — fall through to employee 30-day history
 
     # Employee: own history
-    if target_user and target_user != user_id:
-        return _reply("You do not have permission to view another user's headcount.")
+    if target_user:
+        resolved = _resolve_user_param(ctx, target_user)
+        if resolved and resolved != ctx.user_id:
+            return _reply("You do not have permission to view another user's headcount.")
 
     if target_date:
-        record = meal_service.get_record(target_date, user_id) or MealRecord(date=target_date, user_id=user_id)
+        record = meal_service.get_record(target_date, ctx.user_id) or MealRecord(date=target_date, user_id=ctx.user_id)
         if not record.meal_opt_in:
             status = "opted out (all meals)"
         elif record.opted_out_meals:
@@ -251,10 +371,9 @@ def _handle_headcount(interaction: DiscordInteraction, options: list) -> tuple[s
         return _reply(f"**{target_date}** — Meal: {status} | Location: {record.work_location}")
 
     # 30-day rolling history
-    from datetime import timedelta
     cutoff = str(_date.today() - timedelta(days=30))
     records = sorted(
-        [r for r in meal_service.get_user_history(user_id) if r.date >= cutoff],
+        [r for r in meal_service.get_user_history(ctx.user_id) if r.date >= cutoff],
         key=lambda r: r.date,
         reverse=True,
     )
@@ -272,7 +391,9 @@ def _handle_headcount(interaction: DiscordInteraction, options: list) -> tuple[s
     return _reply("\n".join(lines))
 
 
-def _handle_event(interaction: DiscordInteraction, subcommand: str, options: list) -> tuple[str, bool]:
+def _handle_event(ctx: BotContext) -> tuple[str, bool]:
+    subcommand = ctx.subcommand
+
     if subcommand == "list":
         events = meal_service.list_events_from_db()
         if not events:
@@ -283,18 +404,17 @@ def _handle_event(interaction: DiscordInteraction, subcommand: str, options: lis
         return _reply("\n".join(lines))
 
     if subcommand == "optout":
-        user_id = interaction.get_user().id
-        target_date = _get_option(options, "date")
+        target_date = ctx.options.get("date")
         if not target_date:
             return _reply("Please provide a date.")
         if not meal_service.is_event_day(target_date):
             return _reply(f"{target_date} is not a configured event day. Use `/meal set` to change your meal preference.")
-        return _reply(meal_service.opt_out(target_date, user_id, updated_by=user_id))
+        return _reply(meal_service.opt_out(target_date, ctx.user_id, updated_by=ctx.user_id))
 
-    if not _is_admin(interaction):
+    if not _is_admin(ctx):
         return _reply("You do not have permission to use this command.")
 
-    target_date = _get_option(options, "date")
+    target_date = ctx.options.get("date")
     if not target_date:
         return _reply("Please provide a date.")
 
@@ -306,17 +426,26 @@ def _handle_event(interaction: DiscordInteraction, subcommand: str, options: lis
             f"A special event meal is scheduled for **{target_date}**. "
             f"All employees are opted in by default. Use `/event optout {target_date}` to opt out before the cut-off."
         )
+        posted_to = []
         if settings.announcement_channel_id:
             try:
                 discord_service.send_channel_message(settings.announcement_channel_id, message)
+                posted_to.append("Discord")
             except Exception as exc:
-                logger.error("Failed to post event announcement to channel: %s", exc)
-            return _reply(f"Announcement posted to <#{settings.announcement_channel_id}>.")
+                logger.error("Failed to post event announcement to Discord channel: %s", exc)
+        if settings.gchat_announcement_space:
+            try:
+                gchat_service.send_announcement(settings.gchat_announcement_space, message)
+                posted_to.append("Google Chat")
+            except Exception as exc:
+                logger.error("Failed to post event announcement to GChat space: %s", exc)
+        if posted_to:
+            return _reply(f"Announcement posted to: {', '.join(posted_to)}.")
         return _reply(message, ephemeral=False)
 
     if subcommand == "update":
-        description = _get_option(options, "description") or ""
-        return _reply(meal_service.update_event(target_date, description, set_by=interaction.get_user().id))
+        description = ctx.options.get("description") or ""
+        return _reply(meal_service.update_event(target_date, description, set_by=ctx.user_id))
 
     if subcommand == "delete":
         return _reply(meal_service.delete_event(target_date))
@@ -324,7 +453,9 @@ def _handle_event(interaction: DiscordInteraction, subcommand: str, options: lis
     return _reply("Unknown subcommand.")
 
 
-def _handle_wfh_periods(interaction: DiscordInteraction, subcommand: str, options: list) -> tuple[str, bool]:
+def _handle_wfh_periods(ctx: BotContext) -> tuple[str, bool]:
+    subcommand = ctx.subcommand
+
     if subcommand == "list":
         periods = meal_service.list_wfh_periods()
         if not periods:
@@ -334,108 +465,108 @@ def _handle_wfh_periods(interaction: DiscordInteraction, subcommand: str, option
             lines.append(f"  {p['start_date']} → {p['end_date']}")
         return _reply("\n".join(lines))
 
-    if not _is_admin(interaction):
+    if not _is_admin(ctx):
         return _reply("You do not have permission to manage WFH periods.")
 
-    start_date = _get_option(options, "start_date")
-    end_date = _get_option(options, "end_date")
+    start_date = ctx.options.get("start_date")
+    end_date = ctx.options.get("end_date")
     if not start_date or not end_date:
         return _reply("Please provide both start_date and end_date.")
 
-    user_id = interaction.get_user().id
     if subcommand == "set":
-        return _reply(meal_service.set_wfh_period(start_date, end_date, set_by=user_id))
+        return _reply(meal_service.set_wfh_period(start_date, end_date, set_by=ctx.user_id))
     if subcommand == "delete":
         return _reply(meal_service.delete_wfh_period(start_date, end_date))
     return _reply("Unknown subcommand.")
 
 
-def _handle_meal_type(interaction: DiscordInteraction, subcommand: str, options: list) -> tuple[str, bool]:
+def _handle_meal_type(ctx: BotContext) -> tuple[str, bool]:
+    subcommand = ctx.subcommand
+
     if subcommand == "list":
-        target_date = _get_option(options, "date") or str(_date.today())
+        target_date = ctx.options.get("date") or str(_date.today())
         active = meal_service.get_active_meal_types(target_date)
         if not active:
             return _reply(f"No active meal types for **{target_date}**.")
         labels = [_MEAL_TYPE_LABELS.get(mt, mt) for mt in active]
         return _reply(f"**Active meal types for {target_date}:** {', '.join(labels)}")
 
-    if not _is_admin(interaction):
+    if not _is_admin(ctx):
         return _reply("You do not have permission to use this command.")
 
-    target_date = _get_option(options, "date")
-    meal_type = _get_option(options, "meal_type")
+    target_date = ctx.options.get("date")
+    meal_type = ctx.options.get("meal_type")
     if not target_date or not meal_type:
         return _reply("Please provide both date and meal_type.")
 
-    user_id = interaction.get_user().id
     if subcommand == "activate":
-        return _reply(meal_service.activate_meal_type(target_date, meal_type, set_by=user_id))
+        return _reply(meal_service.activate_meal_type(target_date, meal_type, set_by=ctx.user_id))
     if subcommand == "deactivate":
         return _reply(meal_service.deactivate_meal_type(target_date, meal_type))
     return _reply("Unknown subcommand.")
 
 
-def _handle_team_members(interaction: DiscordInteraction, options: list) -> tuple[str, bool]:
-    if not _is_team_lead(interaction):
+def _handle_team_members(ctx: BotContext) -> tuple[str, bool]:
+    if not _is_team_lead(ctx):
         return _reply("You do not have permission to use this command.")
 
-    user_id = interaction.get_user().id
-    team_id = _get_option(options, "team_id")
+    team_id = ctx.options.get("team_id")
 
     # Admin with no team_id — list all teams
-    if not team_id and _is_admin(interaction):
+    if not team_id and _is_admin(ctx):
         teams = team_service.list_teams()
         if not teams:
             return _reply("No teams configured.")
         lines = ["**All Teams**"]
         for t in teams:
             count = len(team_service.get_team_members(t["team_id"]))
-            lines.append(f"  `{t['team_id']}` — **{t['name']}** | Lead: <@{t['lead_user_id']}> | {count} member(s)")
+            lead_label = _user_label(ctx, t["lead_user_id"])
+            lines.append(f"  `{t['team_id']}` — **{t['name']}** | Lead: {lead_label} | {count} member(s)")
         return _reply("\n".join(lines))
 
     if team_id:
-        if not _is_admin(interaction):
+        if not _is_admin(ctx):
             return _reply("Only Admins can specify a team. Team Leads see their own team.")
         team = team_service.get_team(team_id)
     else:
-        team = team_service.get_user_team(user_id)
+        team = team_service.get_user_team(ctx.user_id)
 
     if not team:
         return _reply("Team not found." if team_id else "You are not assigned to any team.")
 
     members = team_service.get_team_members(team["team_id"])
     month_prefix = str(_date.today())[:7]
+<<<<<<< HEAD
     try:
         wfh_summary = meal_service.get_monthly_wfh_summary(month_prefix)
     except RuntimeError:
         return _reply("Failed to retrieve WFH data. Please try again later.")
+=======
+    wfh_summary = meal_service.get_monthly_wfh_summary(month_prefix)
+    lead_label = _user_label(ctx, team["lead_user_id"])
+>>>>>>> cb480c9 (refactor: make handler platform-agnostic using BotContext with dual response dispatch)
     member_lines = "\n".join(
-        f"  <@{uid}> — WFH this month: {wfh_summary.get(uid, 0)}"
+        f"  {_user_label(ctx, uid)} — WFH this month: {wfh_summary.get(uid, 0)}"
         for uid in members
     ) or "  (no members)"
     return _reply(
-        f"**{team['name']}** (`{team['team_id']}`) — Lead: <@{team['lead_user_id']}>\n"
+        f"**{team['name']}** (`{team['team_id']}`) — Lead: {lead_label}\n"
         f"Members ({len(members)}) — {month_prefix}:\n{member_lines}"
     )
 
 
-def _route_command(interaction: DiscordInteraction) -> tuple[str, bool]:
-    if not interaction.data:
-        return _reply("No interaction data.")
+# ---------------------------------------------------------------------------
+# Command Routing
+# ---------------------------------------------------------------------------
 
-    command = interaction.data.name
-    options = interaction.data.options
-
-    subcommand = None
-    sub_options: list = []
-    if options and options[0].type == 1:
-        subcommand = options[0].name
-        sub_options = options[0].options
+def _route_command(ctx: BotContext) -> tuple[str, bool]:
+    command = ctx.command
+    subcommand = ctx.subcommand
 
     if command == "meal":
         if not subcommand:
             return _reply("Please specify a subcommand.")
-        return _handle_meal(interaction, subcommand, sub_options)
+        return _handle_meal(ctx)
 
     if command == "location":
         if not subcommand:
@@ -443,46 +574,59 @@ def _route_command(interaction: DiscordInteraction) -> tuple[str, bool]:
         handler_fn = _LOCATION_HANDLERS.get(subcommand)
         if not handler_fn:
             return _reply("Unknown subcommand.")
-        return handler_fn(interaction, sub_options)
+        return handler_fn(ctx)
 
     if command == "headcount":
-        return _handle_headcount(interaction, options)
+        return _handle_headcount(ctx)
 
     if command == "team-members":
-        return _handle_team_members(interaction, options)
+        return _handle_team_members(ctx)
 
     if command == "wfh-periods":
         if not subcommand:
             return _reply("Please specify a subcommand.")
-        return _handle_wfh_periods(interaction, subcommand, sub_options)
+        return _handle_wfh_periods(ctx)
 
     if command == "event":
         if not subcommand:
             return _reply("Please specify a subcommand.")
-        return _handle_event(interaction, subcommand, sub_options)
+        return _handle_event(ctx)
 
     if command == "meal-type":
         if not subcommand:
             return _reply("Please specify a subcommand.")
-        return _handle_meal_type(interaction, subcommand, sub_options)
+        return _handle_meal_type(ctx)
 
     return _reply("Unknown command.")
 
 
+# ---------------------------------------------------------------------------
+# Lambda Entry Point
+# ---------------------------------------------------------------------------
+
 def handler(event: dict, context: Any) -> None:
     try:
-        interaction = DiscordInteraction(**event)
+        if "platform" in event:
+            # GChat payload — already a serialized BotContext
+            ctx = BotContext(**event)
+        else:
+            # Discord payload — convert to BotContext
+            interaction = DiscordInteraction(**event)
+            ctx = _discord_to_bot_context(interaction)
     except Exception as exc:
         logger.error("Failed to parse interaction payload: %s", exc)
         return
 
     try:
-        content, ephemeral = _route_command(interaction)
+        content, ephemeral = _route_command(ctx)
     except Exception as exc:
         logger.error("Unhandled error routing command: %s", exc)
         content, ephemeral = "An unexpected error occurred. Please try again.", True
 
     try:
-        discord_service.send_followup(interaction.token, content, ephemeral=ephemeral)
+        if ctx.platform == "discord":
+            discord_service.send_followup(ctx.token, content, ephemeral=ephemeral)
+        elif ctx.platform == "gchat":
+            gchat_service.send_reply(ctx.space, content)
     except Exception as exc:
-        logger.error("Failed to send follow-up to Discord: %s", exc)
+        logger.error("Failed to send response on %s: %s", ctx.platform, exc)

--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -435,7 +435,7 @@ def _handle_event(ctx: BotContext) -> tuple[str, bool]:
                 logger.error("Failed to post event announcement to Discord channel: %s", exc)
         if settings.gchat_announcement_space:
             try:
-                gchat_service.send_announcement(settings.gchat_announcement_space, message)
+                gchat_service.send_message(settings.gchat_announcement_space, message)
                 posted_to.append("Google Chat")
             except Exception as exc:
                 logger.error("Failed to post event announcement to GChat space: %s", exc)
@@ -536,15 +536,11 @@ def _handle_team_members(ctx: BotContext) -> tuple[str, bool]:
 
     members = team_service.get_team_members(team["team_id"])
     month_prefix = str(_date.today())[:7]
-<<<<<<< HEAD
     try:
         wfh_summary = meal_service.get_monthly_wfh_summary(month_prefix)
     except RuntimeError:
         return _reply("Failed to retrieve WFH data. Please try again later.")
-=======
-    wfh_summary = meal_service.get_monthly_wfh_summary(month_prefix)
     lead_label = _user_label(ctx, team["lead_user_id"])
->>>>>>> cb480c9 (refactor: make handler platform-agnostic using BotContext with dual response dispatch)
     member_lines = "\n".join(
         f"  {_user_label(ctx, uid)} — WFH this month: {wfh_summary.get(uid, 0)}"
         for uid in members
@@ -627,6 +623,6 @@ def handler(event: dict, context: Any) -> None:
         if ctx.platform == "discord":
             discord_service.send_followup(ctx.token, content, ephemeral=ephemeral)
         elif ctx.platform == "gchat":
-            gchat_service.send_reply(ctx.space, content)
+            gchat_service.send_message(ctx.space, content)
     except Exception as exc:
         logger.error("Failed to send response on %s: %s", ctx.platform, exc)

--- a/Task-2/app/services/gchat_service.py
+++ b/Task-2/app/services/gchat_service.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import json
+import logging
+import urllib.error
+import urllib.request
+
+import google.auth
+import google.auth.transport.requests
+
+logger = logging.getLogger(__name__)
+
+_CHAT_API_BASE = "https://chat.googleapis.com/v1"
+_SCOPES = ["https://www.googleapis.com/auth/chat.bot"]
+
+_credentials = None
+
+
+def _get_credentials() -> google.auth.credentials.Credentials:
+    """Obtain and cache Google service account credentials for the Chat API."""
+    global _credentials
+    if _credentials is None or not _credentials.valid:
+        _credentials, _ = google.auth.default(scopes=_SCOPES)
+    if not _credentials.valid:
+        _credentials.refresh(google.auth.transport.requests.Request())
+    return _credentials
+
+
+def _authorized_request(url: str, payload: dict, method: str = "POST") -> None:
+    """Send an authenticated request to the Google Chat REST API."""
+    creds = _get_credentials()
+    data = json.dumps(payload).encode()
+    req = urllib.request.Request(
+        url,
+        data=data,
+        headers={
+            "Content-Type": "application/json",
+            "Authorization": f"Bearer {creds.token}",
+        },
+        method=method,
+    )
+    try:
+        with urllib.request.urlopen(req) as resp:
+            logger.info("GChat API call to %s: status=%s", url, resp.status)
+    except urllib.error.HTTPError as e:
+        logger.error("GChat API error: %s %s", e.code, e.reason)
+        raise
+    except urllib.error.URLError as e:
+        logger.error("GChat network error: %s", e.reason)
+        raise
+    except Exception as e:
+        logger.error("GChat unexpected error: %s", e)
+        raise
+
+
+def send_reply(space: str, content: str) -> None:
+    """Send a text message reply to a Google Chat space."""
+    url = f"{_CHAT_API_BASE}/{space}/messages"
+    _authorized_request(url, {"text": content})
+
+
+def send_announcement(space: str, content: str) -> None:
+    """Post a broadcast announcement to a Google Chat space."""
+    url = f"{_CHAT_API_BASE}/{space}/messages"
+    _authorized_request(url, {"text": content})

--- a/Task-2/app/services/gchat_service.py
+++ b/Task-2/app/services/gchat_service.py
@@ -53,13 +53,7 @@ def _authorized_request(url: str, payload: dict, method: str = "POST") -> None:
         raise
 
 
-def send_reply(space: str, content: str) -> None:
-    """Send a text message reply to a Google Chat space."""
-    url = f"{_CHAT_API_BASE}/{space}/messages"
-    _authorized_request(url, {"text": content})
-
-
-def send_announcement(space: str, content: str) -> None:
-    """Post a broadcast announcement to a Google Chat space."""
+def send_message(space: str, content: str) -> None:
+    """Send a text message to a Google Chat space."""
     url = f"{_CHAT_API_BASE}/{space}/messages"
     _authorized_request(url, {"text": content})

--- a/Task-2/register_gchat_commands.py
+++ b/Task-2/register_gchat_commands.py
@@ -1,0 +1,234 @@
+"""
+Google Chat slash command definitions for the Meal Headcount Planner bot.
+
+Google Chat commands are configured manually in the Google Cloud Console:
+    APIs & Services → Google Chat API → Configuration → Slash commands
+
+Command IDs must match _COMMAND_MAP in app/gchat_router.py.
+
+Arguments are passed as plain text after the slash command. The first word
+is the subcommand (for commands that have subcommands), followed by
+positional parameters separated by spaces.
+
+Usage:
+    python register_gchat_commands.py
+"""
+
+# Google Chat does not have typed options like Discord. All arguments are
+# positional text parsed by the router. The structure below documents the
+# expected parameter order for each command/subcommand, mirroring the
+# Discord COMMANDS in register_commands.py.
+
+_STR = "string"
+_BOOL = "boolean"
+_USER = "string"  # Google user ID or email
+
+COMMANDS = [
+    {
+        "command_id": 1,
+        "name": "meal",
+        "description": "Manage your meal preference",
+        "subcommands": [
+            # /meal status [user] [date]
+            {
+                "name": "status",
+                "description": "Check meal status for a date. Team Lead/Admin can specify another user.",
+                "options": [
+                    {"type": _STR, "name": "user", "description": "Target user (Google user ID or email)", "required": False},
+                    {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD). Defaults to today.", "required": False},
+                ],
+            },
+            # /meal set <date> [opt_in] [meal_types] [user]
+            {
+                "name": "set",
+                "description": "Update meal opt-in/out for a date. Team Lead/Admin can specify another user.",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True},
+                    {"type": _BOOL, "name": "opt_in", "description": "true or false", "required": False},
+                    {"type": _STR, "name": "meal_types", "description": "Comma-separated: LUNCH,SNACKS,IFTAR,EVENT_DINNER,OPTIONAL_DINNER", "required": False},
+                    {"type": _USER, "name": "user", "description": "Target user (Google user ID or email)", "required": False},
+                ],
+            },
+            # /meal bulk <start_date> <end_date> <opt_in> [user]
+            {
+                "name": "bulk",
+                "description": "Set meal opt-in/out across a date range. Team Lead/Admin can specify another user.",
+                "options": [
+                    {"type": _STR, "name": "start_date", "description": "Start date (YYYY-MM-DD)", "required": True},
+                    {"type": _STR, "name": "end_date", "description": "End date (YYYY-MM-DD)", "required": True},
+                    {"type": _BOOL, "name": "opt_in", "description": "true or false", "required": True},
+                    {"type": _USER, "name": "user", "description": "Target user (Google user ID or email)", "required": False},
+                ],
+            },
+        ],
+    },
+    {
+        "command_id": 2,
+        "name": "location",
+        "description": "Manage work location",
+        "subcommands": [
+            # /location status [user] [date]
+            {
+                "name": "status",
+                "description": "Check work location for a date. Team Lead/Admin can specify another user.",
+                "options": [
+                    {"type": _STR, "name": "user", "description": "Target user (Google user ID or email)", "required": False},
+                    {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD). Defaults to today.", "required": False},
+                ],
+            },
+            # /location set <date> <location> [user]
+            {
+                "name": "set",
+                "description": "Set work location. WFH auto-opts out of all meals.",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True},
+                    {"type": _STR, "name": "location", "description": "OFFICE or WFH", "required": True},
+                    {"type": _USER, "name": "user", "description": "Target user (Google user ID or email)", "required": False},
+                ],
+            },
+            # /location bulk <start_date> <end_date> <location> [user]
+            {
+                "name": "bulk",
+                "description": "Set work location across a date range. Team Lead/Admin can specify another user.",
+                "options": [
+                    {"type": _STR, "name": "start_date", "description": "Start date (YYYY-MM-DD)", "required": True},
+                    {"type": _STR, "name": "end_date", "description": "End date (YYYY-MM-DD)", "required": True},
+                    {"type": _STR, "name": "location", "description": "OFFICE or WFH", "required": True},
+                    {"type": _USER, "name": "user", "description": "Target user (Google user ID or email)", "required": False},
+                ],
+            },
+        ],
+    },
+    # /headcount [date] [user]
+    {
+        "command_id": 3,
+        "name": "headcount",
+        "description": "Headcount summary (Admin/Team Lead) or own 30-day history (Employee)",
+        "options": [
+            {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": False},
+            {"type": _USER, "name": "user", "description": "Target user (Google user ID or email)", "required": False},
+        ],
+    },
+    # /event announce/optout/list/update/delete
+    {
+        "command_id": 6,
+        "name": "event",
+        "description": "Manage event meal days",
+        "subcommands": [
+            {
+                "name": "announce",
+                "description": "[Admin] Broadcast an announcement for a configured event meal day",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Event date (YYYY-MM-DD)", "required": True},
+                ],
+            },
+            {
+                "name": "optout",
+                "description": "Opt out of an event meal day",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Event date (YYYY-MM-DD)", "required": True},
+                ],
+            },
+            {
+                "name": "list",
+                "description": "Show all configured event days",
+                "options": [],
+            },
+            {
+                "name": "update",
+                "description": "[Admin] Add or update an event day",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Event date (YYYY-MM-DD)", "required": True},
+                    {"type": _STR, "name": "description", "description": "Event description", "required": True},
+                ],
+            },
+            {
+                "name": "delete",
+                "description": "[Admin] Delete a configured event day",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Event date (YYYY-MM-DD)", "required": True},
+                ],
+            },
+        ],
+    },
+    # /wfh-periods set/delete/list
+    {
+        "command_id": 5,
+        "name": "wfh-periods",
+        "description": "Manage company-wide WFH schedules",
+        "subcommands": [
+            {
+                "name": "set",
+                "description": "[Admin] Set a company-wide WFH period",
+                "options": [
+                    {"type": _STR, "name": "start_date", "description": "Start date (YYYY-MM-DD)", "required": True},
+                    {"type": _STR, "name": "end_date", "description": "End date (YYYY-MM-DD)", "required": True},
+                ],
+            },
+            {
+                "name": "delete",
+                "description": "[Admin] Delete a company-wide WFH period",
+                "options": [
+                    {"type": _STR, "name": "start_date", "description": "Start date (YYYY-MM-DD)", "required": True},
+                    {"type": _STR, "name": "end_date", "description": "End date (YYYY-MM-DD)", "required": True},
+                ],
+            },
+            {
+                "name": "list",
+                "description": "List all company-wide WFH periods in the next 2 months",
+                "options": [],
+            },
+        ],
+    },
+    # /team-members [team_id]
+    {
+        "command_id": 4,
+        "name": "team-members",
+        "description": "[Team Lead / Admin] View members of your team. Admin can specify a team.",
+        "options": [
+            {"type": _STR, "name": "team_id", "description": "Team identifier (Admin only)", "required": False},
+        ],
+    },
+    # /meal-type activate/deactivate/list
+    {
+        "command_id": 7,
+        "name": "meal-type",
+        "description": "Manage active meal types per date",
+        "subcommands": [
+            {
+                "name": "activate",
+                "description": "[Admin] Activate a meal type for a specific date",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True},
+                    {"type": _STR, "name": "meal_type", "description": "IFTAR, EVENT_DINNER, or OPTIONAL_DINNER", "required": True},
+                ],
+            },
+            {
+                "name": "deactivate",
+                "description": "[Admin] Deactivate a meal type for a specific date",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD)", "required": True},
+                    {"type": _STR, "name": "meal_type", "description": "IFTAR, EVENT_DINNER, or OPTIONAL_DINNER", "required": True},
+                ],
+            },
+            {
+                "name": "list",
+                "description": "Show active meal types for a date",
+                "options": [
+                    {"type": _STR, "name": "date", "description": "Target date (YYYY-MM-DD). Defaults to today.", "required": False},
+                ],
+            },
+        ],
+    },
+]
+
+
+if __name__ == "__main__":
+    for cmd in COMMANDS:
+        print(f"  ID {cmd['command_id']}: /{cmd['name']} — {cmd['description']}")
+        for sub in cmd.get("subcommands", []):
+            params = " ".join(
+                f"<{o['name']}>" if o["required"] else f"[{o['name']}]"
+                for o in sub["options"]
+            )
+            print(f"    /{cmd['name']} {sub['name']} {params}".rstrip())


### PR DESCRIPTION
Closes #73 

## Dependencies

- PR #74  (gchat-router-jwt-auth-identity) — the GChat Router Lambda that produces the `BotContext` consumed by the refactored handler.

## What does this PR do?

Completes the Google Chat integration by adding response delivery, refactoring the handler to be platform-agnostic, and documenting GChat slash command registration. After this PR, all existing commands work identically on both Discord and Google Chat.

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Refactor
- [ ] Documentation

## What was changed

### 1. GChat Response Service (`app/services/gchat_service.py`)
- `send_reply(space, content)` — sends a text message to a Google Chat space via the REST API (`spaces.messages.create`).
- `send_announcement(space, content)` — posts a broadcast to a configured announcement space.
- Authenticates outbound requests using Google Application Default Credentials with `chat.bot` scope.

### 2. Handler dual-platform refactor (`app/handler.py`)
This is the largest change — the handler was fully Discord-specific and is now platform-agnostic.

- **Entry point detection:** `handler()` checks for `"platform"` key to distinguish GChat (`BotContext` dict) from Discord (`DiscordInteraction` dict) payloads.
- **Discord → BotContext conversion:** `_discord_to_bot_context()` converts `DiscordInteraction` into `BotContext`, resolving Discord guild role IDs to `ADMIN`/`TEAM_LEAD`/`EMPLOYEE` and flattening `CommandOption` objects into a plain dict.
- **Role checks:** `_is_admin()` and `_is_team_lead()` now check `ctx.role` instead of Discord guild role IDs.
- **Option access:** All handlers use `ctx.options.get("name")` dict access instead of iterating `CommandOption` lists.
- **User references:** `_user_label()` returns `<@id>` for Discord and plain text for GChat.
- **GChat user resolution:** `_resolve_user_param()` resolves a Google user ID or email to the internal `userId` via `EXTID#GCHAT#` DynamoDB lookup, falling back to an email query on GSI1.
- **`/event announce` dual broadcast:** Now posts to both Discord channel (`ANNOUNCEMENT_CHANNEL_ID`) and GChat space (`GCHAT_ANNOUNCEMENT_SPACE`) regardless of which platform the admin invokes from.
- **Response dispatch:** Branches on `ctx.platform` — Discord via `discord_service.send_followup()`, GChat via `gchat_service.send_reply()`.

### 3. Command registration reference (`register_gchat_commands.py`)
- Mirrors the structure of `register_commands.py` — nested subcommands with typed options for each command.
- Documents the command IDs (1–7) that must match `_COMMAND_MAP` in `gchat_router.py`.
- Prints a summary when run directly.

## Changelog

Feature: All MHP commands now work on Google Chat with dual-platform response delivery and `/event announce` broadcasting to both platforms

## How to Test

1. Deploy the updated Command Lambda with the refactored `handler.py`.
2. Send a slash command from Discord — verify the existing flow still works (Discord → BotContext → handler → discord_service).
3. Send a slash command from Google Chat — verify the full round-trip (GChat → Router → BotContext → handler → gchat_service → reply in space).
4. Test `/event announce` from either platform — verify the announcement is posted to both the Discord channel and the GChat space.
5. Test GChat user resolution: use `/meal status <email>` from GChat with another user's email.
6. Run `python register_gchat_commands.py` — verify the command list prints correctly.

## How QA Should Test

Affected workflows:
- All existing Discord commands (regression — should be unchanged)
- All Google Chat commands (new)
- `/event announce` dual-platform broadcast (changed)

Specific checks:
- **Discord regression:** Run `/meal status`, `/location set`, `/headcount`, `/event list` from Discord — verify responses are identical to before.
- **GChat end-to-end:** Run the same commands from Google Chat — verify responses arrive in the space.
- **Role enforcement on GChat:** Verify Admin-only commands (e.g., `/event update`) are rejected for `EMPLOYEE` role users.
- **GChat user param:** From GChat, run `/meal status user@example.com` — verify it resolves the email to the correct internal user and shows their record.
- **Dual announce:** Run `/event announce <date>` — confirm messages appear in both Discord channel and GChat space. If one is unconfigured, confirm the other still posts.

## Rollback Plan

- Revert this PR to restore the Discord-only handler. The GChat Router Lambda (PR #74) can remain deployed — it will dispatch to the Command Lambda but responses won't be delivered until this PR is re-applied.

## Checklist

- [x] My code follows the project style guidelines
- [ ] Code passes linting and type checks
- [ ] All tests pass
- [ ] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)

## Screenshots (if applicable)

N/A — backend-only change, no UI.

## Note for Reviewer

- The handler refactor touches every command handler function (signature change from `DiscordInteraction + options list` to `BotContext`). The business logic inside each handler is unchanged — only the way identity, roles, and options are accessed differs.
- `_resolve_user_param()` uses a GSI1 query with email filter as a fallback. For a small internal tool this is acceptable, but a dedicated email GSI would be more efficient at scale.
- Automated tests are out of scope for this iteration (see tech spec §6).
