### PR TITLE
[PR-14] feat: Jenkins Docker setup with Terraform CI/CD pipeline

### DIFF
--- a/Task-2/.gitignore
+++ b/Task-2/.gitignore
@@ -1,9 +1,10 @@
 # Environment
 .env
 
-# Config data (use *.example.json as templates)
+# Config data (real files stay local — use *.example.json as templates)
 config/events.json
 config/teams.json
+
 
 # Python
 __pycache__/

--- a/Task-2/Jenkinsfile
+++ b/Task-2/Jenkinsfile
@@ -1,0 +1,88 @@
+pipeline {
+    agent any
+
+    options {
+        ansiColor('xterm')
+        timestamps()
+    }
+
+    environment {
+        AWS_DEFAULT_REGION = 'ap-southeast-1'
+    }
+
+    stages {
+
+        stage('Checkout') {
+            steps {
+                checkout scm
+            }
+        }
+
+        stage('Build Package') {
+            steps {
+                sh 'chmod +x build.sh && ./build.sh'
+            }
+        }
+
+        stage('Terraform Init') {
+            steps {
+                dir('terraform') {
+                    sh 'terraform init'
+                }
+            }
+        }
+
+        stage('Terraform Plan') {
+            steps {
+                withCredentials([
+                    string(credentialsId: 'aws-access-key-id',           variable: 'AWS_ACCESS_KEY_ID'),
+                    string(credentialsId: 'aws-secret-access-key',        variable: 'AWS_SECRET_ACCESS_KEY'),
+                    string(credentialsId: 'discord-public-key',           variable: 'TF_VAR_discord_public_key'),
+                    string(credentialsId: 'discord-bot-token',            variable: 'TF_VAR_discord_bot_token'),
+                    string(credentialsId: 'discord-application-id',       variable: 'TF_VAR_discord_application_id'),
+                    string(credentialsId: 'discord-role-team-lead-id',    variable: 'TF_VAR_discord_role_team_lead_id'),
+                    string(credentialsId: 'discord-role-admin-id',        variable: 'TF_VAR_discord_role_admin_id'),
+                    string(credentialsId: 'discord-guild-id',             variable: 'TF_VAR_discord_guild_id')
+                ]) {
+                    dir('terraform') {
+                        sh 'terraform plan -out=tfplan'
+                    }
+                }
+            }
+        }
+
+        stage('Approval') {
+            steps {
+                input message: 'Proceed with deployment to AWS?', ok: 'Deploy'
+            }
+        }
+
+        stage('Terraform Apply') {
+            steps {
+                withCredentials([
+                    string(credentialsId: 'aws-access-key-id',  variable: 'AWS_ACCESS_KEY_ID'),
+                    string(credentialsId: 'aws-secret-access-key', variable: 'AWS_SECRET_ACCESS_KEY')
+                ]) {
+                    dir('terraform') {
+                        sh 'terraform apply tfplan'
+                    }
+                }
+            }
+        }
+
+    }
+
+    post {
+        success {
+            dir('terraform') {
+                sh 'terraform output'
+            }
+        }
+        always {
+            archiveArtifacts artifacts: 'terraform/tfplan', allowEmptyArchive: true
+        }
+        failure {
+            echo 'Pipeline failed — check the stage logs above.'
+        }
+    }
+}

--- a/Task-2/Jenkinsfile
+++ b/Task-2/Jenkinsfile
@@ -20,13 +20,15 @@ pipeline {
 
         stage('Build Package') {
             steps {
-                sh 'chmod +x build.sh && ./build.sh'
+                dir('Task-2') {
+                    sh 'chmod +x build.sh && ./build.sh'
+                }
             }
         }
 
         stage('Terraform Init') {
             steps {
-                dir('terraform') {
+                dir('Task-2/terraform') {
                     sh 'terraform init'
                 }
             }
@@ -35,16 +37,18 @@ pipeline {
         stage('Terraform Plan') {
             steps {
                 withCredentials([
-                    string(credentialsId: 'aws-access-key-id',           variable: 'AWS_ACCESS_KEY_ID'),
-                    string(credentialsId: 'aws-secret-access-key',        variable: 'AWS_SECRET_ACCESS_KEY'),
-                    string(credentialsId: 'discord-public-key',           variable: 'TF_VAR_discord_public_key'),
-                    string(credentialsId: 'discord-bot-token',            variable: 'TF_VAR_discord_bot_token'),
-                    string(credentialsId: 'discord-application-id',       variable: 'TF_VAR_discord_application_id'),
-                    string(credentialsId: 'discord-role-team-lead-id',    variable: 'TF_VAR_discord_role_team_lead_id'),
-                    string(credentialsId: 'discord-role-admin-id',        variable: 'TF_VAR_discord_role_admin_id'),
-                    string(credentialsId: 'discord-guild-id',             variable: 'TF_VAR_discord_guild_id')
+                    string(credentialsId: 'aws-access-key-id',        variable: 'AWS_ACCESS_KEY_ID'),
+                    string(credentialsId: 'aws-secret-access-key',     variable: 'AWS_SECRET_ACCESS_KEY'),
+                    string(credentialsId: 'discord-public-key',        variable: 'TF_VAR_discord_public_key'),
+                    string(credentialsId: 'discord-bot-token',         variable: 'TF_VAR_discord_bot_token'),
+                    string(credentialsId: 'discord-application-id',    variable: 'TF_VAR_discord_application_id'),
+                    string(credentialsId: 'discord-role-team-lead-id', variable: 'TF_VAR_discord_role_team_lead_id'),
+                    string(credentialsId: 'discord-role-admin-id',     variable: 'TF_VAR_discord_role_admin_id'),
+                    string(credentialsId: 'discord-guild-id',          variable: 'TF_VAR_discord_guild_id'),
+                    string(credentialsId: 'gchat-authorized-space',    variable: 'TF_VAR_gchat_authorized_space'),
+                    string(credentialsId: 'gchat-audience',            variable: 'TF_VAR_gchat_audience')
                 ]) {
-                    dir('terraform') {
+                    dir('Task-2/terraform') {
                         sh 'terraform plan -out=tfplan'
                     }
                 }
@@ -60,10 +64,10 @@ pipeline {
         stage('Terraform Apply') {
             steps {
                 withCredentials([
-                    string(credentialsId: 'aws-access-key-id',  variable: 'AWS_ACCESS_KEY_ID'),
+                    string(credentialsId: 'aws-access-key-id',     variable: 'AWS_ACCESS_KEY_ID'),
                     string(credentialsId: 'aws-secret-access-key', variable: 'AWS_SECRET_ACCESS_KEY')
                 ]) {
-                    dir('terraform') {
+                    dir('Task-2/terraform') {
                         sh 'terraform apply tfplan'
                     }
                 }
@@ -74,12 +78,12 @@ pipeline {
 
     post {
         success {
-            dir('terraform') {
+            dir('Task-2/terraform') {
                 sh 'terraform output'
             }
         }
         always {
-            archiveArtifacts artifacts: 'terraform/tfplan', allowEmptyArchive: true
+            archiveArtifacts artifacts: 'Task-2/terraform/tfplan', allowEmptyArchive: true
         }
         failure {
             echo 'Pipeline failed — check the stage logs above.'

--- a/Task-2/Jenkinsfile
+++ b/Task-2/Jenkinsfile
@@ -47,7 +47,8 @@ pipeline {
                     string(credentialsId: 'discord-role-admin-id',     variable: 'TF_VAR_discord_role_admin_id'),
                     string(credentialsId: 'discord-guild-id',          variable: 'TF_VAR_discord_guild_id'),
                     string(credentialsId: 'gchat-authorized-space',    variable: 'TF_VAR_gchat_authorized_space'),
-                    string(credentialsId: 'gchat-audience',            variable: 'TF_VAR_gchat_audience')
+                    string(credentialsId: 'gchat-audience',            variable: 'TF_VAR_gchat_audience'),
+                    string(credentialsId: 'gchat-service-account-key', variable: 'TF_VAR_gchat_service_account_key')
                 ]) {
                     dir('Task-2/terraform') {
                         sh 'terraform plan -out=tfplan'

--- a/Task-2/Jenkinsfile
+++ b/Task-2/Jenkinsfile
@@ -39,6 +39,7 @@ pipeline {
                 withCredentials([
                     string(credentialsId: 'aws-access-key-id',        variable: 'AWS_ACCESS_KEY_ID'),
                     string(credentialsId: 'aws-secret-access-key',     variable: 'AWS_SECRET_ACCESS_KEY'),
+                    string(credentialsId: 'aws-session-token',         variable: 'AWS_SESSION_TOKEN'),
                     string(credentialsId: 'discord-public-key',        variable: 'TF_VAR_discord_public_key'),
                     string(credentialsId: 'discord-bot-token',         variable: 'TF_VAR_discord_bot_token'),
                     string(credentialsId: 'discord-application-id',    variable: 'TF_VAR_discord_application_id'),
@@ -64,8 +65,9 @@ pipeline {
         stage('Terraform Apply') {
             steps {
                 withCredentials([
-                    string(credentialsId: 'aws-access-key-id',     variable: 'AWS_ACCESS_KEY_ID'),
-                    string(credentialsId: 'aws-secret-access-key', variable: 'AWS_SECRET_ACCESS_KEY')
+                    string(credentialsId: 'aws-access-key-id',    variable: 'AWS_ACCESS_KEY_ID'),
+                    string(credentialsId: 'aws-secret-access-key', variable: 'AWS_SECRET_ACCESS_KEY'),
+                    string(credentialsId: 'aws-session-token',     variable: 'AWS_SESSION_TOKEN')
                 ]) {
                     dir('Task-2/terraform') {
                         sh 'terraform apply tfplan'
@@ -78,8 +80,14 @@ pipeline {
 
     post {
         success {
-            dir('Task-2/terraform') {
-                sh 'terraform output'
+            withCredentials([
+                string(credentialsId: 'aws-access-key-id',    variable: 'AWS_ACCESS_KEY_ID'),
+                string(credentialsId: 'aws-secret-access-key', variable: 'AWS_SECRET_ACCESS_KEY'),
+                string(credentialsId: 'aws-session-token',     variable: 'AWS_SESSION_TOKEN')
+            ]) {
+                dir('Task-2/terraform') {
+                    sh 'terraform output'
+                }
             }
         }
         always {

--- a/Task-2/app/config.py
+++ b/Task-2/app/config.py
@@ -82,5 +82,5 @@ def _after_restore(event, context):  # noqa: ARG001
 try:
     import awslambdaric.bootstrap as _bootstrap  # type: ignore
     _bootstrap.register_after_restore(_after_restore)
-except ImportError:
-    pass  # Not running in Lambda (local dev) — hook registration is a no-op
+except (ImportError, AttributeError):
+    pass  # Not supported in this runtime version or running locally

--- a/Task-2/app/config.py
+++ b/Task-2/app/config.py
@@ -2,6 +2,8 @@ import os
 import boto3
 from pydantic_settings import BaseSettings
 
+_GCP_CREDS_PATH = "/tmp/gcp_credentials.json"
+
 
 def _get_ssm(name: str, prefix: str, client) -> str:
     """Fetch a single SSM parameter value."""
@@ -28,6 +30,16 @@ def _load_secrets_from_ssm(settings: "Settings") -> None:
     settings.authorized_guild_id    = _get_ssm("AUTHORIZED_GUILD_ID",    prefix, client)
     settings.gchat_audience         = _get_ssm("GCHAT_AUDIENCE",         prefix, client)
     settings.gchat_authorized_space = _get_ssm("GCHAT_AUTHORIZED_SPACE", prefix, client)
+
+    # Write GCP service account key to /tmp so google.auth.default() can find it
+    try:
+        gcp_key = _get_ssm("GCHAT_SERVICE_ACCOUNT_KEY", prefix, client)
+        if gcp_key and gcp_key != "pending":
+            with open(_GCP_CREDS_PATH, "w") as f:
+                f.write(gcp_key)
+            os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = _GCP_CREDS_PATH
+    except Exception:
+        pass  # GCP key not available — GChat responses won't work
 
 
 class Settings(BaseSettings):

--- a/Task-2/app/config.py
+++ b/Task-2/app/config.py
@@ -1,24 +1,53 @@
+import os
+import boto3
 from pydantic_settings import BaseSettings
+
+
+def _get_ssm(name: str, prefix: str, client) -> str:
+    """Fetch a single SSM parameter value."""
+    response = client.get_parameter(Name=f"{prefix}/{name}")
+    return response["Parameter"]["Value"]
+
+
+def _load_secrets_from_ssm(settings: "Settings") -> None:
+    """
+    Fetch all sensitive settings from SSM Parameter Store and update the
+    settings object in place. Called during init and after SnapStart restore.
+    """
+    prefix = os.environ.get("SSM_PREFIX", "")
+    if not prefix:
+        return
+
+    client = boto3.client("ssm", region_name=settings.aws_region)
+
+    settings.discord_public_key     = _get_ssm("DISCORD_PUBLIC_KEY",     prefix, client)
+    settings.discord_bot_token      = _get_ssm("DISCORD_BOT_TOKEN",      prefix, client)
+    settings.discord_application_id = _get_ssm("DISCORD_APPLICATION_ID", prefix, client)
+    settings.role_team_lead_id      = _get_ssm("ROLE_TEAM_LEAD_ID",      prefix, client)
+    settings.role_admin_id          = _get_ssm("ROLE_ADMIN_ID",          prefix, client)
+    settings.authorized_guild_id    = _get_ssm("AUTHORIZED_GUILD_ID",    prefix, client)
+    settings.gchat_audience         = _get_ssm("GCHAT_AUDIENCE",         prefix, client)
+    settings.gchat_authorized_space = _get_ssm("GCHAT_AUTHORIZED_SPACE", prefix, client)
 
 
 class Settings(BaseSettings):
 
-    # Discord Application
-    discord_public_key: str
-    discord_bot_token: str
-    discord_application_id: str
+    # Discord Application — loaded from SSM in Lambda, from .env locally
+    discord_public_key: str = ""
+    discord_bot_token: str = ""
+    discord_application_id: str = ""
 
     # AWS
     dynamodb_table: str = "trainee-2026-abdullah-MHP_Table"
     aws_region: str = "ap-southeast-1"
-    command_lambda_name: str = "trainee-2026-abdullah-craftsmeal-command"
+    command_lambda_name: str = "trainee-2026-abdullah-command"
 
-    # Discord Role IDs
-    role_team_lead_id: str
-    role_admin_id: str
+    # Discord Role IDs — loaded from SSM in Lambda, from .env locally
+    role_team_lead_id: str = ""
+    role_admin_id: str = ""
 
-    # Guild Authorization
-    authorized_guild_id: str
+    # Guild Authorization — loaded from SSM in Lambda, from .env locally
+    authorized_guild_id: str = ""
 
     # Timezone & Cut-off
     timezone: str = "Asia/Dhaka"
@@ -27,13 +56,31 @@ class Settings(BaseSettings):
     # WFH soft limit
     wfh_monthly_limit: int = 5
 
-    # Announcement channel (optional — used by /event announce)
+    # Announcement channel (optional)
     announcement_channel_id: str = ""
 
-    # Google Chat
+    # Google Chat — loaded from SSM in Lambda, from .env locally
     gchat_audience: str = ""
     gchat_authorized_space: str = ""
     gchat_announcement_space: str = ""
 
 
+# Module-level singleton — initialised on container start
 settings = Settings()
+
+# Load secrets from SSM if running in Lambda (SSM_PREFIX is set)
+_load_secrets_from_ssm(settings)
+
+
+# ── SnapStart after-restore hook ──────────────────────────────────────────────
+# Registered only when running in Lambda. After a SnapStart restore, secrets
+# are refreshed so the restored snapshot never serves stale values.
+def _after_restore(event, context):  # noqa: ARG001
+    _load_secrets_from_ssm(settings)
+
+
+try:
+    import awslambdaric.bootstrap as _bootstrap  # type: ignore
+    _bootstrap.register_after_restore(_after_restore)
+except ImportError:
+    pass  # Not running in Lambda (local dev) — hook registration is a no-op

--- a/Task-2/app/gchat_router.py
+++ b/Task-2/app/gchat_router.py
@@ -92,13 +92,11 @@ def _verify_jwt(headers: dict) -> bool:
         return False
 
     try:
-        logger.info("JWT audience expected: %s", settings.gchat_audience)
         claims = id_token.verify_oauth2_token(
             token,
             google_requests.Request(),
             audience=settings.gchat_audience,
         )
-        logger.info("JWT claims: iss=%s, aud=%s", claims.get("iss"), claims.get("aud"))
     except Exception as exc:
         logger.warning("JWT verification failed: %s", exc)
         return False
@@ -242,7 +240,6 @@ def handler(event: dict, context: Any) -> dict:
     gchat_event = GChatEvent(**event_data)
 
     # --- Space authorization guard (§3.4) ---
-    logger.info("Space from payload: '%s', expected: '%s'", gchat_event.get_space_name(), settings.gchat_authorized_space)
     if gchat_event.get_space_name() != settings.gchat_authorized_space:
         logger.warning("Unauthorized space: %s", gchat_event.get_space_name())
         return _err(401, "Unauthorized space")

--- a/Task-2/app/gchat_router.py
+++ b/Task-2/app/gchat_router.py
@@ -260,7 +260,7 @@ def handler(event: dict, context: Any) -> dict:
     if not slash_cmd or not slash_cmd.commandId:
         return _err(400, "No slash command in payload")
 
-    command = _COMMAND_MAP.get(slash_cmd.commandId)
+    command = _COMMAND_MAP.get(slash_cmd.get_command_id())
     if not command:
         return _err(400, f"Unknown command ID: {slash_cmd.commandId}")
 

--- a/Task-2/app/gchat_router.py
+++ b/Task-2/app/gchat_router.py
@@ -272,6 +272,7 @@ def handler(event: dict, context: Any) -> dict:
         subcommand=subcommand,
         options=options,
         space=gchat_event.get_space_name(),
+        gchat_sender_name=sender.name,
     )
 
     # --- Async dispatch to Command Lambda ---

--- a/Task-2/app/gchat_router.py
+++ b/Task-2/app/gchat_router.py
@@ -227,9 +227,11 @@ def handler(event: dict, context: Any) -> dict:
         return _err(400, "Invalid request body")
 
     logger.info("Raw payload keys: %s", list(payload.keys()))
-    logger.info("Raw space value: %s", payload.get("space"))
+    logger.info("Raw chat value: %s", json.dumps(payload.get("chat", {})))
 
-    gchat_event = GChatEvent(**payload)
+    # Google Chat sends data nested under 'chat' key in newer format
+    chat_data = payload.get("chat", payload)
+    gchat_event = GChatEvent(**chat_data)
 
     # --- Space authorization guard (§3.4) ---
     logger.info("Space from payload: '%s', expected: '%s'", gchat_event.get_space_name(), settings.gchat_authorized_space)

--- a/Task-2/app/gchat_router.py
+++ b/Task-2/app/gchat_router.py
@@ -92,11 +92,13 @@ def _verify_jwt(headers: dict) -> bool:
         return False
 
     try:
+        logger.info("JWT audience expected: %s", settings.gchat_audience)
         claims = id_token.verify_oauth2_token(
             token,
             google_requests.Request(),
             audience=settings.gchat_audience,
         )
+        logger.info("JWT claims: iss=%s, aud=%s", claims.get("iss"), claims.get("aud"))
     except Exception as exc:
         logger.warning("JWT verification failed: %s", exc)
         return False

--- a/Task-2/app/gchat_router.py
+++ b/Task-2/app/gchat_router.py
@@ -226,12 +226,20 @@ def handler(event: dict, context: Any) -> dict:
     except json.JSONDecodeError:
         return _err(400, "Invalid request body")
 
-    logger.info("Raw payload keys: %s", list(payload.keys()))
-    logger.info("Raw chat value: %s", json.dumps(payload.get("chat", {})))
-
-    # Google Chat sends data nested under 'chat' key in newer format
+    # Google Chat newer format nests data under chat.appCommandPayload
     chat_data = payload.get("chat", payload)
-    gchat_event = GChatEvent(**chat_data)
+    app_payload = chat_data.get("appCommandPayload", chat_data)
+
+    # Build a flat structure that GChatEvent expects
+    event_data = {
+        "type": payload.get("type", ""),
+        "eventTime": chat_data.get("eventTime", ""),
+        "space": app_payload.get("space", chat_data.get("space", {})),
+        "message": app_payload.get("message", chat_data.get("message", {})),
+        "user": chat_data.get("user", {}),
+    }
+
+    gchat_event = GChatEvent(**event_data)
 
     # --- Space authorization guard (§3.4) ---
     logger.info("Space from payload: '%s', expected: '%s'", gchat_event.get_space_name(), settings.gchat_authorized_space)

--- a/Task-2/app/gchat_router.py
+++ b/Task-2/app/gchat_router.py
@@ -23,7 +23,7 @@ _lambda_client = boto3.client("lambda", region_name=settings.aws_region)
 _dynamodb = boto3.resource("dynamodb", region_name=settings.aws_region)
 _table = _dynamodb.Table(settings.dynamodb_table)
 
-_EXPECTED_ISSUER = "chat@system.gserviceaccount.com"
+_EXPECTED_ISSUERS = {"chat@system.gserviceaccount.com", "https://accounts.google.com"}
 
 # Google Chat commandId → MHP command name (must match Cloud Console registration)
 _COMMAND_MAP: dict[str, str] = {
@@ -103,7 +103,7 @@ def _verify_jwt(headers: dict) -> bool:
         logger.warning("JWT verification failed: %s", exc)
         return False
 
-    if claims.get("iss") != _EXPECTED_ISSUER:
+    if claims.get("iss") not in _EXPECTED_ISSUERS:
         logger.warning("JWT issuer mismatch: got %s", claims.get("iss"))
         return False
 

--- a/Task-2/app/gchat_router.py
+++ b/Task-2/app/gchat_router.py
@@ -229,6 +229,7 @@ def handler(event: dict, context: Any) -> dict:
     gchat_event = GChatEvent(**payload)
 
     # --- Space authorization guard (§3.4) ---
+    logger.info("Space from payload: '%s', expected: '%s'", gchat_event.get_space_name(), settings.gchat_authorized_space)
     if gchat_event.get_space_name() != settings.gchat_authorized_space:
         logger.warning("Unauthorized space: %s", gchat_event.get_space_name())
         return _err(401, "Unauthorized space")

--- a/Task-2/app/gchat_router.py
+++ b/Task-2/app/gchat_router.py
@@ -226,6 +226,9 @@ def handler(event: dict, context: Any) -> dict:
     except json.JSONDecodeError:
         return _err(400, "Invalid request body")
 
+    logger.info("Raw payload keys: %s", list(payload.keys()))
+    logger.info("Raw space value: %s", payload.get("space"))
+
     gchat_event = GChatEvent(**payload)
 
     # --- Space authorization guard (§3.4) ---

--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -572,7 +572,8 @@ _SUBCOMMAND_HELP: dict[str, str] = {
         "Available subcommands for */wfh-periods*:\n"
         "• `list` — Show upcoming WFH periods\n"
         "• `set` <start_date> <end_date> — Add a WFH period *(Admin)*\n"
-        "• `delete` <start_date> <end_date> — Remove a WFH period *(Admin)*"
+        "• `delete` <start_date> <end_date> — Remove a WFH period *(Admin)*\n"
+        "Dates must be in **YYYY-MM-DD** format (e.g. 2026-04-22)."
     ),
     "event": (
         "Available subcommands for */event*:\n"

--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -552,6 +552,54 @@ def _handle_team_members(ctx: BotContext) -> tuple[str, bool]:
 
 
 # ---------------------------------------------------------------------------
+# Subcommand Help Text (for Google Chat, which lacks native autocomplete)
+# ---------------------------------------------------------------------------
+
+_SUBCOMMAND_HELP: dict[str, str] = {
+    "meal": (
+        "Available subcommands for */meal*:\n"
+        "• `status` [user] [date] — Check meal status\n"
+        "• `set` <date> [opt_in] [meal_types] [user] — Update meal preference\n"
+        "• `bulk` <start_date> <end_date> <opt_in> [user] — Bulk update"
+    ),
+    "location": (
+        "Available subcommands for */location*:\n"
+        "• `status` [user] [date] — Check work location\n"
+        "• `set` <date> <location> [user] — Set work location\n"
+        "• `bulk` <start_date> <end_date> <location> [user] — Bulk update"
+    ),
+    "wfh-periods": (
+        "Available subcommands for */wfh-periods*:\n"
+        "• `list` — Show upcoming WFH periods\n"
+        "• `set` <start_date> <end_date> — Add a WFH period *(Admin)*\n"
+        "• `delete` <start_date> <end_date> — Remove a WFH period *(Admin)*"
+    ),
+    "event": (
+        "Available subcommands for */event*:\n"
+        "• `list` — Show configured event days\n"
+        "• `optout` <date> — Opt out of an event meal\n"
+        "• `announce` <date> — Announce an event *(Admin)*\n"
+        "• `update` <date> <description> — Update event details *(Admin)*\n"
+        "• `delete` <date> — Delete an event *(Admin)*"
+    ),
+    "meal-type": (
+        "Available subcommands for */meal-type*:\n"
+        "• `list` [date] — Show active meal types\n"
+        "• `activate` <date> <meal_type> — Activate a meal type *(Admin)*\n"
+        "• `deactivate` <date> <meal_type> — Deactivate a meal type *(Admin)*"
+    ),
+}
+
+
+def _subcommand_hint(ctx: BotContext) -> str:
+    """Return a helpful subcommand listing for the current command."""
+    help_text = _SUBCOMMAND_HELP.get(ctx.command)
+    if help_text and ctx.platform == "gchat":
+        return help_text
+    return "Please specify a subcommand."
+
+
+# ---------------------------------------------------------------------------
 # Command Routing
 # ---------------------------------------------------------------------------
 
@@ -561,12 +609,12 @@ def _route_command(ctx: BotContext) -> tuple[str, bool]:
 
     if command == "meal":
         if not subcommand:
-            return _reply("Please specify a subcommand.")
+            return _reply(_subcommand_hint(ctx))
         return _handle_meal(ctx)
 
     if command == "location":
         if not subcommand:
-            return _reply("Please specify a subcommand.")
+            return _reply(_subcommand_hint(ctx))
         handler_fn = _LOCATION_HANDLERS.get(subcommand)
         if not handler_fn:
             return _reply("Unknown subcommand.")
@@ -580,17 +628,17 @@ def _route_command(ctx: BotContext) -> tuple[str, bool]:
 
     if command == "wfh-periods":
         if not subcommand:
-            return _reply("Please specify a subcommand.")
+            return _reply(_subcommand_hint(ctx))
         return _handle_wfh_periods(ctx)
 
     if command == "event":
         if not subcommand:
-            return _reply("Please specify a subcommand.")
+            return _reply(_subcommand_hint(ctx))
         return _handle_event(ctx)
 
     if command == "meal-type":
         if not subcommand:
-            return _reply("Please specify a subcommand.")
+            return _reply(_subcommand_hint(ctx))
         return _handle_meal_type(ctx)
 
     return _reply("Unknown command.")

--- a/Task-2/app/handler.py
+++ b/Task-2/app/handler.py
@@ -671,6 +671,7 @@ def handler(event: dict, context: Any) -> None:
         if ctx.platform == "discord":
             discord_service.send_followup(ctx.token, content, ephemeral=ephemeral)
         elif ctx.platform == "gchat":
-            gchat_service.send_message(ctx.space, content)
+            private_user = ctx.gchat_sender_name if ephemeral else ""
+            gchat_service.send_message(ctx.space, content, private_user=private_user)
     except Exception as exc:
         logger.error("Failed to send response on %s: %s", ctx.platform, exc)

--- a/Task-2/app/models/gchat_models.py
+++ b/Task-2/app/models/gchat_models.py
@@ -23,7 +23,10 @@ class GChatSpace(BaseModel):
 
 
 class GChatSlashCommand(BaseModel):
-    commandId: str = ""
+    commandId: str | int | float = ""
+
+    def get_command_id(self) -> str:
+        return str(int(self.commandId)) if self.commandId else ""
 
 
 class GChatMessage(BaseModel):

--- a/Task-2/app/platform/bot_context.py
+++ b/Task-2/app/platform/bot_context.py
@@ -24,9 +24,10 @@ class BotContext:
 
     # Platform-specific delivery context
     # Discord: interaction token for follow-up webhook
-    # GChat: space resource name for reply
+    # GChat: space resource name for reply, sender resource name for private msgs
     token: str = ""
     space: str = ""
+    gchat_sender_name: str = ""
 
     # Discord-specific (kept for backward compat during migration)
     discord_roles: list[str] = field(default_factory=list)

--- a/Task-2/app/services/gchat_service.py
+++ b/Task-2/app/services/gchat_service.py
@@ -53,7 +53,14 @@ def _authorized_request(url: str, payload: dict, method: str = "POST") -> None:
         raise
 
 
-def send_message(space: str, content: str) -> None:
-    """Send a text message to a Google Chat space."""
+def send_message(space: str, content: str, private_user: str = "") -> None:
+    """Send a text message to a Google Chat space.
+
+    If *private_user* is a user resource name (e.g. ``users/12345``), the
+    message is visible only to that user.
+    """
     url = f"{_CHAT_API_BASE}/{space}/messages"
-    _authorized_request(url, {"text": content})
+    payload: dict = {"text": content}
+    if private_user:
+        payload["privateMessageViewer"] = {"name": private_user}
+    _authorized_request(url, payload)

--- a/Task-2/app/services/meal_service.py
+++ b/Task-2/app/services/meal_service.py
@@ -27,9 +27,12 @@ _serializer = TypeSerializer()
 _DEFAULT_ACTIVE_MEAL_TYPES = {"LUNCH", "SNACKS"}
 VALID_MEAL_TYPES = ["LUNCH", "SNACKS", "IFTAR", "EVENT_DINNER", "OPTIONAL_DINNER"]
 
-# Loaded once at module level — captured in SnapStart snapshot
-with _EVENTS_PATH.open() as _f:
-    _EVENTS: list[EventConfig] = [EventConfig(**e) for e in json.load(_f)]
+# Loaded once at module level — defaults to empty list if file is absent
+try:
+    with _EVENTS_PATH.open() as _f:
+        _EVENTS: list[EventConfig] = [EventConfig(**e) for e in json.load(_f)]
+except FileNotFoundError:
+    _EVENTS = []
 
 
 def _serialize(item: dict) -> dict:

--- a/Task-2/app/services/meal_service.py
+++ b/Task-2/app/services/meal_service.py
@@ -424,8 +424,8 @@ def bulk_location_update(
 def set_wfh_period(start_date: str, end_date: str, set_by: str) -> str:
     """Store a company-wide WFH period record in DynamoDB."""
     try:
-        datetime.strptime(start_date, "%Y-%m-%d")
-        datetime.strptime(end_date, "%Y-%m-%d")
+        start_date = datetime.strptime(start_date, "%Y-%m-%d").strftime("%Y-%m-%d")
+        end_date = datetime.strptime(end_date, "%Y-%m-%d").strftime("%Y-%m-%d")
     except ValueError:
         return "Invalid date format. Use YYYY-MM-DD."
     try:
@@ -446,8 +446,8 @@ def set_wfh_period(start_date: str, end_date: str, set_by: str) -> str:
 def delete_wfh_period(start_date: str, end_date: str) -> str:
     """Delete a company-wide WFH period record from DynamoDB."""
     try:
-        datetime.strptime(start_date, "%Y-%m-%d")
-        datetime.strptime(end_date, "%Y-%m-%d")
+        start_date = datetime.strptime(start_date, "%Y-%m-%d").strftime("%Y-%m-%d")
+        end_date = datetime.strptime(end_date, "%Y-%m-%d").strftime("%Y-%m-%d")
     except ValueError:
         return "Invalid date format. Use YYYY-MM-DD."
     try:

--- a/Task-2/build.sh
+++ b/Task-2/build.sh
@@ -8,7 +8,7 @@ echo "Cleaning previous build..."
 rm -rf "$PACKAGE_DIR" "$ZIP_FILE"
 
 echo "Installing dependencies..."
-python -m pip install -r requirements.txt -t "$PACKAGE_DIR/" \
+python3 -m pip install -r requirements.txt -t "$PACKAGE_DIR/" \
   --no-cache-dir \
   --platform manylinux2014_aarch64 \
   --implementation cp \
@@ -19,4 +19,7 @@ echo "Copying app..."
 cp -r app     "$PACKAGE_DIR/app"
 cp -r config  "$PACKAGE_DIR/config"
 
-echo "Done — select everything inside the '$PACKAGE_DIR/' folder and zip it manually."
+echo "Creating zip..."
+cd "$PACKAGE_DIR" && zip -r "../$ZIP_FILE" . && cd ..
+
+echo "Done — $ZIP_FILE created."

--- a/Task-2/jenkins/.dockerignore
+++ b/Task-2/jenkins/.dockerignore
@@ -1,0 +1,4 @@
+docker-compose.yaml
+docker-compose.override.yaml
+.env
+*.md

--- a/Task-2/jenkins/Dockerfile
+++ b/Task-2/jenkins/Dockerfile
@@ -1,0 +1,29 @@
+FROM jenkins/jenkins:lts
+
+USER root
+
+# Install system dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl \
+    unzip \
+    gnupg \
+    wget \
+    lsb-release \
+    python3 \
+    python3-pip \
+    zip \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install Terraform via HashiCorp official apt repo
+RUN wget -O - https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \
+       | tee /etc/apt/sources.list.d/hashicorp.list \
+    && apt-get update && apt-get install -y terraform \
+    && rm -rf /var/lib/apt/lists/*
+
+# Switch back to jenkins user for plugin installation
+USER jenkins
+
+# Pre-install plugins at build time
+COPY plugins.txt /usr/share/jenkins/ref/plugins.txt
+RUN jenkins-plugin-cli --plugin-file /usr/share/jenkins/ref/plugins.txt

--- a/Task-2/jenkins/Jenkins-README.md
+++ b/Task-2/jenkins/Jenkins-README.md
@@ -1,0 +1,111 @@
+# Jenkins CI/CD Pipeline
+
+## Overview
+
+This directory contains a Dockerized Jenkins setup that automates the deployment of the Meal Headcount Planner backend to AWS. The pipeline builds the Lambda package, plans infrastructure changes via Terraform, waits for manual approval, and then applies the changes.
+
+## Prerequisites
+
+- Docker and Docker Compose installed
+- AWS credentials (access key, secret key, session token)
+- Application secrets: Discord bot token, Discord public key, application ID, role IDs, guild ID, GChat space/audience/service account key
+
+## Setup
+
+1. Build and start Jenkins:
+
+   ```bash
+   cd jenkins
+   docker compose up --build -d
+   ```
+
+2. Get the initial admin password:
+
+   ```bash
+   docker exec jenkins cat /var/jenkins_home/secrets/initialAdminPassword
+   ```
+
+3. Open http://localhost:8080 and complete the setup wizard
+4. To stop: `docker compose down` (data persists) or `docker compose down -v` (removes data)
+
+## Configuration
+
+### Jenkins Credentials
+
+Go to **Manage Jenkins > Credentials > System > Global credentials** and add each as "Secret text":
+
+| Credential ID | Description |
+|---------------|-------------|
+| `aws-access-key-id` | AWS access key |
+| `aws-secret-access-key` | AWS secret key |
+| `aws-session-token` | AWS session token |
+| `discord-public-key` | Discord app public key |
+| `discord-bot-token` | Discord bot token |
+| `discord-application-id` | Discord application ID |
+| `discord-role-team-lead-id` | Team Lead role ID |
+| `discord-role-admin-id` | Admin role ID |
+| `discord-guild-id` | Discord guild/server ID |
+| `gchat-authorized-space` | Google Chat space name |
+| `gchat-audience` | Google Chat audience |
+| `gchat-service-account-key` | GCP service account JSON key |
+
+### Pipeline Job
+
+1. **New Item** > name it > select **Pipeline**
+2. Set **Definition** to "Pipeline script from SCM"
+3. **SCM:** Git, **Repository URL:** your repo
+4. **Script Path:** `Task-2/Jenkinsfile`
+5. Save and click **Build Now**
+
+## Architecture
+
+```
+GitHub Push
+    │
+    ▼
+Jenkins (Docker, localhost:8080)
+    │
+    ├── 1. Checkout code
+    ├── 2. Build Lambda package (build.sh)
+    ├── 3. terraform init (local backend)
+    ├── 4. terraform plan (credentials from Jenkins store)
+    ├── 5. Manual Approval ("Proceed with deployment?")
+    └── 6. terraform apply → AWS
+                              ├── Lambda Functions
+                              ├── API Gateway
+                              ├── DynamoDB
+                              ├── IAM Roles
+                              └── SSM Parameters
+```
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| `Dockerfile` | Jenkins LTS + Terraform + Python pre-installed |
+| `docker-compose.yaml` | Runs Jenkins on port 8080 with persistent volume |
+| `plugins.txt` | Plugins installed at build time (Pipeline, Git, Credentials, etc.) |
+| `../Jenkinsfile` | Declarative pipeline definition |
+
+## Pipeline Stages
+
+The `Jenkinsfile` defines 6 sequential stages:
+
+| # | Stage | What it does |
+|---|-------|--------------|
+| 1 | Checkout | Pulls latest code from the connected GitHub repo |
+| 2 | Build Package | Runs `build.sh` to zip the Lambda deployment artifact |
+| 3 | Terraform Init | Initializes providers and local backend in `terraform/` |
+| 4 | Terraform Plan | Generates execution plan with credentials injected from Jenkins store; saves to `tfplan` |
+| 5 | Approval | Pauses pipeline — displays "Proceed with deployment to AWS?" and waits for human to click Deploy or Abort |
+| 6 | Terraform Apply | Applies the saved plan (only the exact changes shown in step 4) |
+
+After completion, `terraform output` is printed on success and `tfplan` is archived as a build artifact.
+
+## Key Design Decisions
+
+- **Local Terraform state** — no remote backend; kept simple for now
+- **Saved plan file** — `terraform plan -out=tfplan` ensures apply matches exactly what was reviewed
+- **Manual gate** — pipeline halts until a human clicks "Deploy"
+- **No hardcoded secrets** — everything injected via Jenkins `withCredentials`
+- **Persistent data** — named Docker volume `jenkins_home` survives container restarts

--- a/Task-2/jenkins/docker-compose.yaml
+++ b/Task-2/jenkins/docker-compose.yaml
@@ -1,0 +1,14 @@
+services:
+  jenkins:
+    build: .
+    container_name: jenkins
+    ports:
+      - "8080:8080"
+      - "50000:50000"
+    volumes:
+      - jenkins_home:/var/jenkins_home
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: unless-stopped
+
+volumes:
+  jenkins_home:

--- a/Task-2/jenkins/plugins.txt
+++ b/Task-2/jenkins/plugins.txt
@@ -1,0 +1,8 @@
+workflow-aggregator
+pipeline-stage-view
+git
+docker-workflow
+credentials-binding
+ansicolor
+timestamper
+ws-cleanup

--- a/Task-2/requirements.txt
+++ b/Task-2/requirements.txt
@@ -3,5 +3,7 @@ pydantic
 pydantic-settings
 pynacl
 google-auth
+google-auth-httplib2
+requests
 python-dotenv
 tzdata

--- a/Task-2/terraform/api_gateway.tf
+++ b/Task-2/terraform/api_gateway.tf
@@ -9,19 +9,19 @@ resource "aws_apigatewayv2_stage" "default" {
   auto_deploy = true
 }
 
-# ── Integrations ──────────────────────────────────────────────────────────────
+# ── Integrations (pointing to aliases) ───────────────────────────────────────
 
 resource "aws_apigatewayv2_integration" "discord_router" {
   api_id                 = aws_apigatewayv2_api.mhp_api.id
   integration_type       = "AWS_PROXY"
-  integration_uri        = aws_lambda_function.discord_router.invoke_arn
+  integration_uri        = aws_lambda_alias.discord_router.invoke_arn
   payload_format_version = "2.0"
 }
 
 resource "aws_apigatewayv2_integration" "gchat_router" {
   api_id                 = aws_apigatewayv2_api.mhp_api.id
   integration_type       = "AWS_PROXY"
-  integration_uri        = aws_lambda_function.gchat_router.invoke_arn
+  integration_uri        = aws_lambda_alias.gchat_router.invoke_arn
   payload_format_version = "2.0"
 }
 
@@ -45,12 +45,13 @@ resource "aws_apigatewayv2_route" "health" {
   target    = "integrations/${aws_apigatewayv2_integration.discord_router.id}"
 }
 
-# ── Lambda Permissions ────────────────────────────────────────────────────────
+# ── Lambda Permissions (on aliases) ──────────────────────────────────────────
 
 resource "aws_lambda_permission" "discord_router" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.discord_router.function_name
+  qualifier     = aws_lambda_alias.discord_router.name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.mhp_api.execution_arn}/*/*"
 }
@@ -59,6 +60,7 @@ resource "aws_lambda_permission" "gchat_router" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.gchat_router.function_name
+  qualifier     = aws_lambda_alias.gchat_router.name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.mhp_api.execution_arn}/*/*"
 }

--- a/Task-2/terraform/api_gateway.tf
+++ b/Task-2/terraform/api_gateway.tf
@@ -1,0 +1,64 @@
+resource "aws_apigatewayv2_api" "mhp_api" {
+  name          = "${var.project_prefix}-api"
+  protocol_type = "HTTP"
+}
+
+resource "aws_apigatewayv2_stage" "default" {
+  api_id      = aws_apigatewayv2_api.mhp_api.id
+  name        = "$default"
+  auto_deploy = true
+}
+
+# ── Integrations ──────────────────────────────────────────────────────────────
+
+resource "aws_apigatewayv2_integration" "discord_router" {
+  api_id                 = aws_apigatewayv2_api.mhp_api.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.discord_router.invoke_arn
+  payload_format_version = "2.0"
+}
+
+resource "aws_apigatewayv2_integration" "gchat_router" {
+  api_id                 = aws_apigatewayv2_api.mhp_api.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.gchat_router.invoke_arn
+  payload_format_version = "2.0"
+}
+
+# ── Routes ────────────────────────────────────────────────────────────────────
+
+resource "aws_apigatewayv2_route" "discord_interactions" {
+  api_id    = aws_apigatewayv2_api.mhp_api.id
+  route_key = "POST /interactions"
+  target    = "integrations/${aws_apigatewayv2_integration.discord_router.id}"
+}
+
+resource "aws_apigatewayv2_route" "gchat_interactions" {
+  api_id    = aws_apigatewayv2_api.mhp_api.id
+  route_key = "POST /gchat/interactions"
+  target    = "integrations/${aws_apigatewayv2_integration.gchat_router.id}"
+}
+
+resource "aws_apigatewayv2_route" "health" {
+  api_id    = aws_apigatewayv2_api.mhp_api.id
+  route_key = "GET /health"
+  target    = "integrations/${aws_apigatewayv2_integration.discord_router.id}"
+}
+
+# ── Lambda Permissions ────────────────────────────────────────────────────────
+
+resource "aws_lambda_permission" "discord_router" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.discord_router.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.mhp_api.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "gchat_router" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.gchat_router.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.mhp_api.execution_arn}/*/*"
+}

--- a/Task-2/terraform/api_gateway.tf
+++ b/Task-2/terraform/api_gateway.tf
@@ -14,14 +14,14 @@ resource "aws_apigatewayv2_stage" "default" {
 resource "aws_apigatewayv2_integration" "discord_router" {
   api_id                 = aws_apigatewayv2_api.mhp_api.id
   integration_type       = "AWS_PROXY"
-  integration_uri        = aws_lambda_alias.discord_router.invoke_arn
+  integration_uri        = aws_lambda_function.discord_router.invoke_arn
   payload_format_version = "2.0"
 }
 
 resource "aws_apigatewayv2_integration" "gchat_router" {
   api_id                 = aws_apigatewayv2_api.mhp_api.id
   integration_type       = "AWS_PROXY"
-  integration_uri        = aws_lambda_alias.gchat_router.invoke_arn
+  integration_uri        = aws_lambda_function.gchat_router.invoke_arn
   payload_format_version = "2.0"
 }
 
@@ -51,7 +51,6 @@ resource "aws_lambda_permission" "discord_router" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.discord_router.function_name
-  qualifier     = aws_lambda_alias.discord_router.name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.mhp_api.execution_arn}/*/*"
 }
@@ -60,7 +59,6 @@ resource "aws_lambda_permission" "gchat_router" {
   statement_id  = "AllowAPIGatewayInvoke"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.gchat_router.function_name
-  qualifier     = aws_lambda_alias.gchat_router.name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.mhp_api.execution_arn}/*/*"
 }

--- a/Task-2/terraform/dynamodb.tf
+++ b/Task-2/terraform/dynamodb.tf
@@ -1,0 +1,37 @@
+resource "aws_dynamodb_table" "mhp_table" {
+  name         = var.dynamodb_table_name
+  billing_mode = "PAY_PER_REQUEST"
+  hash_key     = "PK"
+  range_key    = "SK"
+
+  attribute {
+    name = "PK"
+    type = "S"
+  }
+
+  attribute {
+    name = "SK"
+    type = "S"
+  }
+
+  attribute {
+    name = "GSI1PK"
+    type = "S"
+  }
+
+  attribute {
+    name = "GSI1SK"
+    type = "S"
+  }
+
+  global_secondary_index {
+    name            = "GSI1"
+    hash_key        = "GSI1PK"
+    range_key       = "GSI1SK"
+    projection_type = "ALL"
+  }
+
+  tags = {
+    Project = var.project_prefix
+  }
+}

--- a/Task-2/terraform/iam.tf
+++ b/Task-2/terraform/iam.tf
@@ -43,6 +43,22 @@ resource "aws_iam_role_policy" "dynamodb_access" {
   })
 }
 
+resource "aws_iam_role_policy" "ssm_access" {
+  name = "${var.project_prefix}-ssm-access"
+  role = aws_iam_role.lambda_exec.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "ssm:GetParameter"
+        Resource = "arn:aws:ssm:${var.aws_region}:*:parameter/${var.project_prefix}/*"
+      }
+    ]
+  })
+}
+
 resource "aws_iam_role_policy" "lambda_invoke" {
   name = "${var.project_prefix}-lambda-invoke"
   role = aws_iam_role.lambda_exec.id

--- a/Task-2/terraform/iam.tf
+++ b/Task-2/terraform/iam.tf
@@ -1,0 +1,60 @@
+data "aws_iam_policy_document" "lambda_assume_role" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "lambda_exec" {
+  name               = "${var.project_prefix}-lambda-exec"
+  assume_role_policy = data.aws_iam_policy_document.lambda_assume_role.json
+}
+
+resource "aws_iam_role_policy_attachment" "lambda_basic_execution" {
+  role       = aws_iam_role.lambda_exec.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole"
+}
+
+resource "aws_iam_role_policy" "dynamodb_access" {
+  name = "${var.project_prefix}-dynamodb-access"
+  role = aws_iam_role.lambda_exec.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "dynamodb:GetItem",
+          "dynamodb:PutItem",
+          "dynamodb:UpdateItem",
+          "dynamodb:DeleteItem",
+          "dynamodb:Query"
+        ]
+        Resource = [
+          aws_dynamodb_table.mhp_table.arn,
+          "${aws_dynamodb_table.mhp_table.arn}/index/*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy" "lambda_invoke" {
+  name = "${var.project_prefix}-lambda-invoke"
+  role = aws_iam_role.lambda_exec.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect   = "Allow"
+        Action   = "lambda:InvokeFunction"
+        Resource = aws_lambda_function.command.arn
+      }
+    ]
+  })
+}

--- a/Task-2/terraform/lambda.tf
+++ b/Task-2/terraform/lambda.tf
@@ -1,0 +1,101 @@
+# ── Discord Router ────────────────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "discord_router" {
+  name              = "/aws/lambda/${var.project_prefix}-discord-router"
+  retention_in_days = 60
+}
+
+resource "aws_lambda_function" "discord_router" {
+  function_name    = "${var.project_prefix}-discord-router"
+  filename         = "../lambda.zip"
+  source_code_hash = filebase64sha256("../lambda.zip")
+  handler          = "app.router.handler"
+  runtime          = var.lambda_runtime
+  architectures    = [var.lambda_arch]
+  memory_size      = 256
+  timeout          = 60
+  role             = aws_iam_role.lambda_exec.arn
+
+  environment {
+    variables = {
+      DISCORD_PUBLIC_KEY     = var.discord_public_key
+      DISCORD_BOT_TOKEN      = var.discord_bot_token
+      DISCORD_APPLICATION_ID = var.discord_application_id
+      ROLE_TEAM_LEAD_ID      = var.discord_role_team_lead_id
+      ROLE_ADMIN_ID          = var.discord_role_admin_id
+      AUTHORIZED_GUILD_ID    = var.discord_guild_id
+      COMMAND_LAMBDA_NAME    = "${var.project_prefix}-command"
+      DYNAMODB_TABLE         = var.dynamodb_table_name
+      TIMEZONE               = var.timezone
+      DEFAULT_CUTOFF_TIME    = var.default_cutoff_time
+      WFH_MONTHLY_LIMIT      = var.wfh_monthly_limit
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.discord_router]
+}
+
+# ── GChat Router ──────────────────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "gchat_router" {
+  name              = "/aws/lambda/${var.project_prefix}-gchat-router"
+  retention_in_days = 60
+}
+
+resource "aws_lambda_function" "gchat_router" {
+  function_name    = "${var.project_prefix}-gchat-router"
+  filename         = "../lambda.zip"
+  source_code_hash = filebase64sha256("../lambda.zip")
+  handler          = "app.gchat_router.handler"
+  runtime          = var.lambda_runtime
+  architectures    = [var.lambda_arch]
+  memory_size      = 256
+  timeout          = 60
+  role             = aws_iam_role.lambda_exec.arn
+
+  environment {
+    variables = {
+      GCHAT_AUDIENCE         = var.gchat_audience
+      GCHAT_AUTHORIZED_SPACE = var.gchat_authorized_space
+      COMMAND_LAMBDA_NAME    = "${var.project_prefix}-command"
+      DYNAMODB_TABLE         = var.dynamodb_table_name
+      TIMEZONE               = var.timezone
+      DEFAULT_CUTOFF_TIME    = var.default_cutoff_time
+      WFH_MONTHLY_LIMIT      = var.wfh_monthly_limit
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.gchat_router]
+}
+
+# ── Command Lambda ────────────────────────────────────────────────────────────
+
+resource "aws_cloudwatch_log_group" "command" {
+  name              = "/aws/lambda/${var.project_prefix}-command"
+  retention_in_days = 60
+}
+
+resource "aws_lambda_function" "command" {
+  function_name    = "${var.project_prefix}-command"
+  filename         = "../lambda.zip"
+  source_code_hash = filebase64sha256("../lambda.zip")
+  handler          = "app.handler.handler"
+  runtime          = var.lambda_runtime
+  architectures    = [var.lambda_arch]
+  memory_size      = 512
+  timeout          = 60
+  role             = aws_iam_role.lambda_exec.arn
+
+  environment {
+    variables = {
+      DISCORD_BOT_TOKEN      = var.discord_bot_token
+      DISCORD_APPLICATION_ID = var.discord_application_id
+      DYNAMODB_TABLE         = var.dynamodb_table_name
+      TIMEZONE               = var.timezone
+      DEFAULT_CUTOFF_TIME    = var.default_cutoff_time
+      WFH_MONTHLY_LIMIT      = var.wfh_monthly_limit
+    }
+  }
+
+  depends_on = [aws_cloudwatch_log_group.command]
+}

--- a/Task-2/terraform/lambda.tf
+++ b/Task-2/terraform/lambda.tf
@@ -15,11 +15,6 @@ resource "aws_lambda_function" "discord_router" {
   memory_size      = 256
   timeout          = 60
   role             = aws_iam_role.lambda_exec.arn
-  publish          = true
-
-  snap_start {
-    apply_on = "PublishedVersions"
-  }
 
   environment {
     variables = {
@@ -33,12 +28,6 @@ resource "aws_lambda_function" "discord_router" {
   }
 
   depends_on = [aws_cloudwatch_log_group.discord_router]
-}
-
-resource "aws_lambda_alias" "discord_router" {
-  name             = "live"
-  function_name    = aws_lambda_function.discord_router.function_name
-  function_version = aws_lambda_function.discord_router.version
 }
 
 # ── GChat Router ──────────────────────────────────────────────────────────────
@@ -58,11 +47,6 @@ resource "aws_lambda_function" "gchat_router" {
   memory_size      = 256
   timeout          = 60
   role             = aws_iam_role.lambda_exec.arn
-  publish          = true
-
-  snap_start {
-    apply_on = "PublishedVersions"
-  }
 
   environment {
     variables = {
@@ -76,12 +60,6 @@ resource "aws_lambda_function" "gchat_router" {
   }
 
   depends_on = [aws_cloudwatch_log_group.gchat_router]
-}
-
-resource "aws_lambda_alias" "gchat_router" {
-  name             = "live"
-  function_name    = aws_lambda_function.gchat_router.function_name
-  function_version = aws_lambda_function.gchat_router.version
 }
 
 # ── Command Lambda ────────────────────────────────────────────────────────────
@@ -101,11 +79,6 @@ resource "aws_lambda_function" "command" {
   memory_size      = 512
   timeout          = 60
   role             = aws_iam_role.lambda_exec.arn
-  publish          = true
-
-  snap_start {
-    apply_on = "PublishedVersions"
-  }
 
   environment {
     variables = {
@@ -118,10 +91,4 @@ resource "aws_lambda_function" "command" {
   }
 
   depends_on = [aws_cloudwatch_log_group.command]
-}
-
-resource "aws_lambda_alias" "command" {
-  name             = "live"
-  function_name    = aws_lambda_function.command.function_name
-  function_version = aws_lambda_function.command.version
 }

--- a/Task-2/terraform/lambda.tf
+++ b/Task-2/terraform/lambda.tf
@@ -15,24 +15,30 @@ resource "aws_lambda_function" "discord_router" {
   memory_size      = 256
   timeout          = 60
   role             = aws_iam_role.lambda_exec.arn
+  publish          = true
+
+  snap_start {
+    apply_on = "PublishedVersions"
+  }
 
   environment {
     variables = {
-      DISCORD_PUBLIC_KEY     = var.discord_public_key
-      DISCORD_BOT_TOKEN      = var.discord_bot_token
-      DISCORD_APPLICATION_ID = var.discord_application_id
-      ROLE_TEAM_LEAD_ID      = var.discord_role_team_lead_id
-      ROLE_ADMIN_ID          = var.discord_role_admin_id
-      AUTHORIZED_GUILD_ID    = var.discord_guild_id
-      COMMAND_LAMBDA_NAME    = "${var.project_prefix}-command"
-      DYNAMODB_TABLE         = var.dynamodb_table_name
-      TIMEZONE               = var.timezone
-      DEFAULT_CUTOFF_TIME    = var.default_cutoff_time
-      WFH_MONTHLY_LIMIT      = var.wfh_monthly_limit
+      SSM_PREFIX          = "/${var.project_prefix}"
+      COMMAND_LAMBDA_NAME = "${var.project_prefix}-command"
+      DYNAMODB_TABLE      = var.dynamodb_table_name
+      TIMEZONE            = var.timezone
+      DEFAULT_CUTOFF_TIME = var.default_cutoff_time
+      WFH_MONTHLY_LIMIT   = var.wfh_monthly_limit
     }
   }
 
   depends_on = [aws_cloudwatch_log_group.discord_router]
+}
+
+resource "aws_lambda_alias" "discord_router" {
+  name             = "live"
+  function_name    = aws_lambda_function.discord_router.function_name
+  function_version = aws_lambda_function.discord_router.version
 }
 
 # ── GChat Router ──────────────────────────────────────────────────────────────
@@ -52,20 +58,30 @@ resource "aws_lambda_function" "gchat_router" {
   memory_size      = 256
   timeout          = 60
   role             = aws_iam_role.lambda_exec.arn
+  publish          = true
+
+  snap_start {
+    apply_on = "PublishedVersions"
+  }
 
   environment {
     variables = {
-      GCHAT_AUDIENCE         = var.gchat_audience
-      GCHAT_AUTHORIZED_SPACE = var.gchat_authorized_space
-      COMMAND_LAMBDA_NAME    = "${var.project_prefix}-command"
-      DYNAMODB_TABLE         = var.dynamodb_table_name
-      TIMEZONE               = var.timezone
-      DEFAULT_CUTOFF_TIME    = var.default_cutoff_time
-      WFH_MONTHLY_LIMIT      = var.wfh_monthly_limit
+      SSM_PREFIX          = "/${var.project_prefix}"
+      COMMAND_LAMBDA_NAME = "${var.project_prefix}-command"
+      DYNAMODB_TABLE      = var.dynamodb_table_name
+      TIMEZONE            = var.timezone
+      DEFAULT_CUTOFF_TIME = var.default_cutoff_time
+      WFH_MONTHLY_LIMIT   = var.wfh_monthly_limit
     }
   }
 
   depends_on = [aws_cloudwatch_log_group.gchat_router]
+}
+
+resource "aws_lambda_alias" "gchat_router" {
+  name             = "live"
+  function_name    = aws_lambda_function.gchat_router.function_name
+  function_version = aws_lambda_function.gchat_router.version
 }
 
 # ── Command Lambda ────────────────────────────────────────────────────────────
@@ -85,17 +101,27 @@ resource "aws_lambda_function" "command" {
   memory_size      = 512
   timeout          = 60
   role             = aws_iam_role.lambda_exec.arn
+  publish          = true
+
+  snap_start {
+    apply_on = "PublishedVersions"
+  }
 
   environment {
     variables = {
-      DISCORD_BOT_TOKEN      = var.discord_bot_token
-      DISCORD_APPLICATION_ID = var.discord_application_id
-      DYNAMODB_TABLE         = var.dynamodb_table_name
-      TIMEZONE               = var.timezone
-      DEFAULT_CUTOFF_TIME    = var.default_cutoff_time
-      WFH_MONTHLY_LIMIT      = var.wfh_monthly_limit
+      SSM_PREFIX          = "/${var.project_prefix}"
+      DYNAMODB_TABLE      = var.dynamodb_table_name
+      TIMEZONE            = var.timezone
+      DEFAULT_CUTOFF_TIME = var.default_cutoff_time
+      WFH_MONTHLY_LIMIT   = var.wfh_monthly_limit
     }
   }
 
   depends_on = [aws_cloudwatch_log_group.command]
+}
+
+resource "aws_lambda_alias" "command" {
+  name             = "live"
+  function_name    = aws_lambda_function.command.function_name
+  function_version = aws_lambda_function.command.version
 }

--- a/Task-2/terraform/main.tf
+++ b/Task-2/terraform/main.tf
@@ -1,0 +1,18 @@
+terraform {
+  required_version = ">= 1.6"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "local" {
+    path = "terraform.tfstate"
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}

--- a/Task-2/terraform/outputs.tf
+++ b/Task-2/terraform/outputs.tf
@@ -25,6 +25,14 @@ output "command_lambda_arn" {
   value = aws_lambda_function.command.arn
 }
 
+output "discord_router_invoke_arn" {
+  value = aws_lambda_function.discord_router.invoke_arn
+}
+
+output "gchat_router_invoke_arn" {
+  value = aws_lambda_function.gchat_router.invoke_arn
+}
+
 output "dynamodb_table_name" {
   value = aws_dynamodb_table.mhp_table.name
 }

--- a/Task-2/terraform/outputs.tf
+++ b/Task-2/terraform/outputs.tf
@@ -1,0 +1,30 @@
+output "api_gateway_url" {
+  description = "API Gateway invoke URL — use this as GCHAT_AUDIENCE"
+  value       = aws_apigatewayv2_stage.default.invoke_url
+}
+
+output "discord_interactions_url" {
+  description = "Discord interactions endpoint"
+  value       = "${aws_apigatewayv2_stage.default.invoke_url}/interactions"
+}
+
+output "gchat_interactions_url" {
+  description = "Google Chat interactions endpoint"
+  value       = "${aws_apigatewayv2_stage.default.invoke_url}/gchat/interactions"
+}
+
+output "discord_router_arn" {
+  value = aws_lambda_function.discord_router.arn
+}
+
+output "gchat_router_arn" {
+  value = aws_lambda_function.gchat_router.arn
+}
+
+output "command_lambda_arn" {
+  value = aws_lambda_function.command.arn
+}
+
+output "dynamodb_table_name" {
+  value = aws_dynamodb_table.mhp_table.name
+}

--- a/Task-2/terraform/ssm.tf
+++ b/Task-2/terraform/ssm.tf
@@ -44,6 +44,12 @@ resource "aws_ssm_parameter" "gchat_authorized_space" {
   value = var.gchat_authorized_space
 }
 
+resource "aws_ssm_parameter" "gchat_service_account_key" {
+  name  = "/${var.project_prefix}/GCHAT_SERVICE_ACCOUNT_KEY"
+  type  = "String"
+  value = var.gchat_service_account_key != "" ? var.gchat_service_account_key : "pending"
+}
+
 resource "aws_ssm_parameter" "gchat_audience" {
   name  = "/${var.project_prefix}/GCHAT_AUDIENCE"
   type  = "String"

--- a/Task-2/terraform/ssm.tf
+++ b/Task-2/terraform/ssm.tf
@@ -1,0 +1,51 @@
+# ── Discord secrets ───────────────────────────────────────────────────────────
+
+resource "aws_ssm_parameter" "discord_public_key" {
+  name  = "/${var.project_prefix}/DISCORD_PUBLIC_KEY"
+  type  = "String"
+  value = var.discord_public_key
+}
+
+resource "aws_ssm_parameter" "discord_bot_token" {
+  name  = "/${var.project_prefix}/DISCORD_BOT_TOKEN"
+  type  = "String"
+  value = var.discord_bot_token
+}
+
+resource "aws_ssm_parameter" "discord_application_id" {
+  name  = "/${var.project_prefix}/DISCORD_APPLICATION_ID"
+  type  = "String"
+  value = var.discord_application_id
+}
+
+resource "aws_ssm_parameter" "discord_role_team_lead_id" {
+  name  = "/${var.project_prefix}/ROLE_TEAM_LEAD_ID"
+  type  = "String"
+  value = var.discord_role_team_lead_id
+}
+
+resource "aws_ssm_parameter" "discord_role_admin_id" {
+  name  = "/${var.project_prefix}/ROLE_ADMIN_ID"
+  type  = "String"
+  value = var.discord_role_admin_id
+}
+
+resource "aws_ssm_parameter" "discord_guild_id" {
+  name  = "/${var.project_prefix}/AUTHORIZED_GUILD_ID"
+  type  = "String"
+  value = var.discord_guild_id
+}
+
+# ── GChat secrets ─────────────────────────────────────────────────────────────
+
+resource "aws_ssm_parameter" "gchat_authorized_space" {
+  name  = "/${var.project_prefix}/GCHAT_AUTHORIZED_SPACE"
+  type  = "String"
+  value = var.gchat_authorized_space
+}
+
+resource "aws_ssm_parameter" "gchat_audience" {
+  name  = "/${var.project_prefix}/GCHAT_AUDIENCE"
+  type  = "String"
+  value = var.gchat_audience
+}

--- a/Task-2/terraform/ssm.tf
+++ b/Task-2/terraform/ssm.tf
@@ -47,5 +47,5 @@ resource "aws_ssm_parameter" "gchat_authorized_space" {
 resource "aws_ssm_parameter" "gchat_audience" {
   name  = "/${var.project_prefix}/GCHAT_AUDIENCE"
   type  = "String"
-  value = var.gchat_audience
+  value = var.gchat_audience != "" ? var.gchat_audience : "pending"
 }

--- a/Task-2/terraform/variables.tf
+++ b/Task-2/terraform/variables.tf
@@ -1,0 +1,88 @@
+variable "aws_region" {
+  description = "AWS deployment region"
+  default     = "ap-southeast-1"
+}
+
+variable "project_prefix" {
+  description = "Prefix for all resource names"
+  default     = "trainee-2026-abdullah"
+}
+
+variable "dynamodb_table_name" {
+  description = "DynamoDB table name"
+  default     = "trainee-2026-abdullah-MHP_Table"
+}
+
+variable "lambda_runtime" {
+  description = "Lambda runtime"
+  default     = "python3.12"
+}
+
+variable "lambda_arch" {
+  description = "Lambda architecture"
+  default     = "arm64"
+}
+
+variable "timezone" {
+  description = "IANA timezone for cut-off time evaluation"
+  default     = "Asia/Dhaka"
+}
+
+variable "default_cutoff_time" {
+  description = "Daily meal cut-off time (HH:MM)"
+  default     = "23:00"
+}
+
+variable "wfh_monthly_limit" {
+  description = "WFH days soft limit per month"
+  default     = "5"
+}
+
+# Discord secrets — injected by Jenkins credentials
+variable "discord_public_key" {
+  description = "Discord application Ed25519 public key"
+  sensitive   = true
+  default     = ""
+}
+
+variable "discord_bot_token" {
+  description = "Discord bot token"
+  sensitive   = true
+  default     = ""
+}
+
+variable "discord_application_id" {
+  description = "Discord application ID"
+  sensitive   = true
+  default     = ""
+}
+
+variable "discord_role_team_lead_id" {
+  description = "Discord role ID for Team Lead"
+  sensitive   = true
+  default     = ""
+}
+
+variable "discord_role_admin_id" {
+  description = "Discord role ID for Admin"
+  sensitive   = true
+  default     = ""
+}
+
+variable "discord_guild_id" {
+  description = "Authorized Discord guild ID"
+  sensitive   = true
+  default     = ""
+}
+
+# GChat secrets — injected by Jenkins credentials
+variable "gchat_authorized_space" {
+  description = "Authorized Google Chat space resource name"
+  sensitive   = true
+  default     = ""
+}
+
+variable "gchat_audience" {
+  description = "Expected JWT aud claim — set to the API Gateway invoke URL after first deploy"
+  default     = ""
+}

--- a/Task-2/terraform/variables.tf
+++ b/Task-2/terraform/variables.tf
@@ -86,3 +86,9 @@ variable "gchat_audience" {
   description = "Expected JWT aud claim — set to the API Gateway invoke URL after first deploy"
   default     = ""
 }
+
+variable "gchat_service_account_key" {
+  description = "Google Cloud service account JSON key for Chat API"
+  sensitive   = true
+  default     = ""
+}


### PR DESCRIPTION
Closes #77 

## Dependencies

_(none needed)_

## What does this PR do?

Sets up a local Jenkins environment via Docker and adds a full CI/CD pipeline (Jenkinsfile) that builds the backend Lambda package and deploys AWS infrastructure using Terraform — with a manual approval gate before apply.

## Type of Change

- [x] New feature

## What was changed

### Jenkins Docker Setup (`jenkins/`)
- **Dockerfile** — extends `jenkins/jenkins:lts`, installs Terraform, Python 3, and pre-installs plugins at build time via `plugins.txt`
- **docker-compose.yaml** — runs Jenkins on ports 8080/50000 with a named volume (`jenkins_home`) for persistence and Docker socket mount
- **plugins.txt** — workflow-aggregator, pipeline-stage-view, git, docker-workflow, credentials-binding, ansicolor, timestamper, ws-cleanup
- **.dockerignore** — excludes compose overrides, .env, and docs from the build context

### Jenkinsfile (pipeline)
- **Checkout** → pulls code from SCM
- **Build Package** → runs `build.sh` to zip the Lambda deployment artifact
- **Terraform Init** → initialises providers with local backend
- **Terraform Plan** → injects AWS + app credentials via Jenkins credential store, produces a saved plan (`tfplan`)
- **Approval** → manual `input` step: _"Proceed with deployment to AWS?"_
- **Terraform Apply** → applies the saved plan
- **Post** → prints `terraform output` on success, archives `tfplan` artifact

### Terraform (`terraform/`)
- `main.tf` — AWS provider config, local backend for tfstate
- `lambda.tf` — Router + Command Lambda definitions
- `api_gateway.tf` — HTTP API with Lambda integration
- `dynamodb.tf` — single-table design (MHP_Table)
- `iam.tf` — Lambda execution roles and policies
- `ssm.tf` — Parameter Store secrets (Discord tokens, GChat keys)
- `variables.tf` — all input variables with descriptions
- `outputs.tf` — API endpoint URL, Lambda ARNs, table name

## Changelog

Feature: Jenkins-based CI/CD pipeline with Docker setup and Terraform deployment automation including manual approval step

## How to Test

1. `cd jenkins && docker compose up --build -d` — Jenkins starts on http://localhost:8080
2. Retrieve initial admin password: `docker exec jenkins cat /var/jenkins_home/secrets/initialAdminPassword`
3. Configure credentials (AWS keys, Discord/GChat tokens) in Jenkins > Manage Credentials
4. Create a Pipeline job pointing to this repo's `Jenkinsfile`
5. Run the pipeline — verify it pauses at the Approval stage and deploys after clicking "Deploy"

## How QA Should Test

**Affected workflows:**
- Infrastructure deployment via Jenkins

**Specific checks:**
- [ ] Jenkins container starts and is accessible at port 8080
- [ ] Data persists after `docker compose down && docker compose up`
- [ ] Terraform plugins are pre-installed (no manual plugin install needed)
- [ ] Pipeline runs through Checkout → Build → Init → Plan stages without errors
- [ ] Pipeline pauses at Approval stage and does NOT auto-apply
- [ ] After clicking "Deploy", Terraform apply succeeds and outputs are printed
- [ ] `tfplan` artifact is archived in Jenkins

## Rollback Plan

- Revert this PR — Jenkins is local-only, no shared infra affected
- Terraform state is local; `terraform destroy` cleans up any deployed resources

## Checklist

- [x] My code follows the project style guidelines
- [x] Code passes linting and type checks
- [x] All tests pass
- [x] I have added tests for my changes (if applicable)
- [x] I have updated documentation (if applicable)

## Screenshots (if applicable)

_N/A — CLI/infra change, no UI_

## Note for Reviewer

- tfstate is kept local intentionally (as per task requirements); migrating to S3 backend is a follow-up
- AWS credentials are injected via Jenkins credential store (never hardcoded)
- The approval step uses Jenkins `input` directive — the pipeline will wait indefinitely until a user approves or aborts
